### PR TITLE
Save the query file to the Drupal temp file directory rather than /tmp

### DIFF
--- a/includes/blast_ui.form_per_program.inc
+++ b/includes/blast_ui.form_per_program.inc
@@ -414,7 +414,7 @@ function blast_ui_per_blast_program_form_submit($form, &$form_state) {
   if (isset($form_state['qFlag'])) {
     if ($form_state['qFlag'] == 'seqQuery') {
       $seq_content = $form_state['values']['FASTA'];
-      $blastjob['query_file'] = '/tmp/' . date('YMd_His') . '_query.fasta';
+      $blastjob['query_file'] = variable_get('file_temporary_path', file_directory_temp()) . '/' . date('YMd_His') . '_query.fasta';
       file_put_contents ($blastjob['query_file'], $seq_content);
     }
     elseif ($form_state['qFlag'] == 'upQuery') {

--- a/includes/blast_ui.services.inc
+++ b/includes/blast_ui.services.inc
@@ -547,7 +547,7 @@ function blast_ui_getblastJobId( $query_type, $db_type, $seqQuery, $Databasekey,
        }
     }
 
-   $query = '/tmp/' . date( 'YMd_His' ) . '_query.fasta';
+   $query = variable_get('file_temporary_path', file_directory_temp()) . '/' . date( 'YMd_His' ) . '_query.fasta';
    file_put_contents( $query, $seqQuery );
    $blastdb_node      = node_load( $Databasekey );
    $blastdb_name      = $blastdb_node->db_name;


### PR DESCRIPTION
On our server apache isn't allowed to write to /tmp and Drupal stores its temp files somewhere else.
