### PR TITLE
Use tripal_get_files_dir to get the output directory

### DIFF
--- a/includes/blast_ui.form_per_program.inc
+++ b/includes/blast_ui.form_per_program.inc
@@ -526,8 +526,7 @@ your sequence headers include pipes (i.e.: | ) they adhere to '
 
     // We want to save all result files (.asn, .xml, .tsv, .html) in the public files directory.
     // Usually [drupal root]/sites/default/files.
-    $output_dir = variable_get('file_public_path', conf_path() . '/files')
-      . DIRECTORY_SEPARATOR . 'tripal' . DIRECTORY_SEPARATOR . 'tripal_blast';
+    $output_dir = tripal_get_files_dir('tripal_blast');
     $output_filestub = $output_dir . DIRECTORY_SEPARATOR . date('YMd_His') . '.blast';
 
     $job_args = array(


### PR DESCRIPTION
During installation this module creates an output files directory with tripal_create_files_dir. 

The proper way to get the path to this directory later is tripal_get_files_dir, and the current hardcoded path doesn't always match the output of that function.
