### PR TITLE
Check if the upload field is available before loading the file

### DIFF
--- a/includes/blast_ui.form_per_program.inc
+++ b/includes/blast_ui.form_per_program.inc
@@ -299,7 +299,10 @@ function blast_ui_per_blast_program_form_validate($form, &$form_state) {
   //----------------
   // @todo: We are currently not validating uploaded files are valid FASTA.
   // First check to see if we have an upload & if so then validate it.
-  $file = file_load($form_state['values']['UPLOAD']);
+  $file = null;
+  if(isset($form_state['values']['UPLOAD'])) {
+    $file = file_load($form_state['values']['UPLOAD']);
+  }
   // If the $file is populated then this is a newly uploaded, temporary file.
   if (is_object($file)) {
     $form_state['qFlag'] = 'upQuery';


### PR DESCRIPTION
We experienced an error when we disabled the file upload option. The error stated: ```unknown index 'UPLOAD'```. We added a simple fix to check if the index has been set before loading the file. This way it won't complain if the option is disabled.

Thanks,
Abdullah Almsaeed
Member of Dr. Staton's lab