### PR TITLE
fixed typo part->parts

### DIFF
--- a/api/blast_ui.api.inc
+++ b/api/blast_ui.api.inc
@@ -742,7 +742,7 @@ function convert_tsv2gff3($blast_tsv,$blast_gff){
     $queryId = $parts[0];
     $subjectStart = $parts[8];
     $subjectEnd = $parts[9];
-    $queryStart = $part[6];
+    $queryStart = $parts[6];
     $queryEnd = $parts[7];
     $eval = $parts[10];
     $hspInfo = "$queryId,$subjectStart,$subjectEnd,$queryStart,$queryEnd";


### PR DESCRIPTION
Oops. I had a typo on line 783. $part[6] should have been $parts[6].