### PR TITLE
fixed typo part=>parts in after fetching from upstream 7.x-1.x

### DIFF
--- a/api/blast_ui.api.inc
+++ b/api/blast_ui.api.inc
@@ -780,7 +780,7 @@ function convert_tsv2gff3($blast_tsv,$blast_gff){
     $q = $parts[0];
     $ss = $parts[8];
     $se = $parts[9];
-    $qs = $part[6];
+    $qs = $parts[6];
     $qe = $parts[7];
     $e = $parts[10];
      


### PR DESCRIPTION
Oops. I had a typo. 

I fixed a typo, $part[6] to $parts[6]. This pull request is build from a fetch from the most current master. 