### PR TITLE
need ;& between argumetns for gbrowes link out

### DIFF
--- a/includes/blast_ui.linkouts.inc
+++ b/includes/blast_ui.linkouts.inc
@@ -242,9 +242,9 @@ function tripal_blast_generate_linkout_gbrowse($url_prefix, $hit, $info, $option
     )
   );
   
-  // For some reason GBrowse expects semi-colons (;) to delineate query paramters 
+  // For some reason GBrowse expects semi-colons (;&) to delineate query paramters 
   // whereas Drupal throws ampherstands (&) in. This is to fix that.
-  $url = str_replace('&',';', $url);
+  $url = str_replace('&',';&', $url);
   
   return $url;
 


### PR DESCRIPTION
GBrowse linkout was giving me an error.  I changed the find and replace from  `$url = str_replace('&',';', $url);` to `$url = str_replace('&',';&', $url);` and it is working for me now.