### PR TITLE
Update custom_linkouts.rst

### DIFF
--- a/docs/dev_guide/custom_linkouts.rst
+++ b/docs/dev_guide/custom_linkouts.rst
@@ -7,7 +7,7 @@ To create custom link-outs for Tripal BLAST you need to first create your own Dr
 
 Once you have a custom module you need to implement hook_blast_linkout_info() to tell Tripal BLAST about your custom link-out. You do this by creating a function with the name of your module replacing the word "hook". For example:
 
-.. code:: php
+.. code-block:: php
 
   /**
    * Implements hook_blast_linkout_info().
@@ -41,7 +41,7 @@ Once you have a custom module you need to implement hook_blast_linkout_info() to
 
 Next you need to implement the process function that you indicated. This function is given a number of variables providing information about the hit, etc. and is expected to generate a fully rendered link based on that information. For example,
 
-.. code:: php
+.. code-block:: php
 
   /**
    * Generate a link to the UofS Genome Browser for a given hit.


### PR DESCRIPTION
Noticed your code blocks dont have php styling https://tripal-blast-ui.readthedocs.io/en/latest/dev_guide/custom_linkouts.html

<img width="982" alt="screen shot 2018-11-25 at 10 25 09 pm" src="https://user-images.githubusercontent.com/7063154/48991471-03741280-f101-11e8-84c1-b584aa7dcc2b.png">


using the code-block directive instead of  the code directive ensures styling is correct: see https://stackoverflow.com/questions/34845889/whats-the-difference-between-the-code-and-code-block-directives-in-rest