### PR TITLE
Trim the path of the database to remove spaces

### DIFF
--- a/includes/blast_ui.node.inc
+++ b/includes/blast_ui.node.inc
@@ -362,7 +362,7 @@ function blastdb_insert($node) {
   db_insert('blastdb')->fields(array(
     'nid'                 => $node->nid,
     'name'                => $node->db_name,
-    'path'                => $node->db_path,
+    'path'                => trim($node->db_path),
     'dbtype'              => $node->db_dbtype,
     'dbxref_id_regex'     => $regex,
     'dbxref_db_id'        => $db_id,


### PR DESCRIPTION
This is a fix for issue #58

This simple fix uses the `trim` function to remove leading and trailing spaces form the db path before inserting it into the database.

It would be best to test the if the file exists before inserting but this would fail in some setups that have the user running jobs different than the apache user. 

Thanks

