### PR TITLE
Add version in blast_ui.info to avoid security update warning on site

### DIFF
--- a/blast_ui.info
+++ b/blast_ui.info
@@ -4,5 +4,6 @@ configure = admin/tripal/extension/tripal_blast/blast_ui
 project = tripal_blast
 package = Tripal Extensions
 core = 7.x
+version = 7.x-1.x-dev
 
 dependencies[] = libraries


### PR DESCRIPTION
Version needs to be set in .info file to allow people to use the github dev version of this module on their drupal site. This is needed so we don't get a security warning.
Before:
![Screenshot from 2019-04-18 11-10-44](https://user-images.githubusercontent.com/26550071/56378579-ba654d80-61ca-11e9-8e9b-4569acb66cb1.png)
After:
![Screenshot from 2019-04-18 11-10-07](https://user-images.githubusercontent.com/26550071/56378591-bfc29800-61ca-11e9-967c-29101436c452.png)
