### PR TITLE
Corrected iterative variables for BLAST report

### DIFF
--- a/theme/blast_report.tpl.php
+++ b/theme/blast_report.tpl.php
@@ -137,8 +137,8 @@ $no_hits = TRUE;
 
         // Save some information needed for the hit visualization.
         $target_name = '';
-        $q_name = $xml->{'BlastOutput_query-def'};
-        $query_size = $xml->{'BlastOutput_query-len'};
+        $q_name = $iteration->{'Iteration_query-def'};
+        $query_size = $iteration->{'Iteration_query-len'};
         $target_size = $iteration->{'Iteration_stat'}->{'Statistics'}->{'Statistics_db-len'};
 
         if ($children_count != 0) {


### PR DESCRIPTION
Previously variables mapped to first sequence within input fasta, causing problems with hit visualization for all other input sequences.