### PR TITLE
Remove unused default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ after_script:
   - ./cc-test-reporter after-build clover.xml --debug -t clover -p /var/www/html/sites/all/modules/custom/tripal_blast --exit-code $TRAVIS_TEST_RESULT
 script:
   - docker run -it -d --rm --name tripal -v "$(pwd)":/modules/tripal_blast statonlab/tripal3
-  - sleep 30 # We pause here so postgres and apache complete booting up
+  - sleep 45 # We pause here so postgres and apache complete booting up
  #install blast
   - docker exec -it tripal bash -c "cp /modules/tripal_blast/ncbi-blast-2.2.30+/bin/* /usr/local/bin"
   - docker exec -it tripal drush pm-enable -y blast_ui

--- a/includes/blast_ui.form_per_program.inc
+++ b/includes/blast_ui.form_per_program.inc
@@ -251,7 +251,6 @@ function blast_ui_per_blast_program_form($form, $form_state) {
           '%max_size' => round(file_upload_max_size() / 1024 / 1024,1) . 'MB'
         )
       ),
-      '#default_value' => variable_get($db_file_id, ''),
       '#upload_validators' => array(
         'file_validate_extensions' => array('fasta fna fa'),
         'file_validate_size' => array(file_upload_max_size()),
@@ -444,8 +443,10 @@ function blast_ui_per_blast_program_form_submit($form, &$form_state) {
     // NOTE: We can't support subject because we need to generate the ASN.1+ format
     // to provide multiple download type options from the same BLAST
     $blastdb_with_path = $form_state['upDB_path'];
+    $blast_path = variable_get('blast_path', '');
+    $makeblast_db = $blast_path . 'makeblastdb';
     $result = NULL;
-    exec('makeblastdb -in ' . escapeshellarg($blastdb_with_path) . ' -dbtype ' . escapeshellarg($mdb_type) . ' -parse_seqids 2>&1', $result);
+    exec(escapeshellarg($makeblast_db) . ' -in ' . escapeshellarg($blastdb_with_path) . ' -dbtype ' . escapeshellarg($mdb_type) . ' -parse_seqids 2>&1', $result);
 
     // Check that the BLAST database was made correctly.
     $result = implode('<br />', $result);


### PR DESCRIPTION
This PR is in response to issue #78. 

After testing it was determined that no default can be supplied for this field and a message to that effect is already added. As such, this PR removes the default value. I also found a small bug regarding the `makeblastdb` command not using the configured path so that is fixed in this PR as well.