### PR TITLE
Updated checking for file ending suffix.

### DIFF
--- a/api/blast_ui.api.inc
+++ b/api/blast_ui.api.inc
@@ -199,8 +199,21 @@ function run_BLAST_tripal_job($program, $query, $database, $output_filestub, $op
   $blast_threads = variable_get('blast_threads', 1);
 
   // Strip the extension off the BLAST target
-  $database = preg_replace("/(.*)\.[pn]\w\w$/", '$1', $database);
+  $suffix = ['.ndb', '.nhr', '.nin', '.not', '.nsq', '.ntf', '.nto',
+    '.pdb', '.phr', '.pin', '.pot', '.psq', '.ptf', '.pto'];
+  $database = str_replace($suffix,'',$database);
 
+  // Check that the database exists before trying to execute the job.
+  if (!(file_exists($database . '.nsq') OR file_exists($database . '.psq'))) {
+    tripal_report_error(
+      'blast_ui',
+      TRIPAL_ERROR,
+      "Unable to find the BLAST database (ie: @db). Please ensure you have supplied the absolute path not including the file format endings.",
+      array('@db' => $database),
+      array('print' => TRUE)
+    );
+    return FALSE;
+  }
 
   // The BLAST executeable.
   $program = $blast_path . $program;

--- a/includes/blast_ui.form_per_program.inc
+++ b/includes/blast_ui.form_per_program.inc
@@ -478,16 +478,17 @@ function blast_ui_per_blast_program_form_submit($form, &$form_state) {
   $blastjob['target_file'] = $blastdb_with_path;
 
   // Determine the path to the blast database with extension.
-  if ($mdb_type == 'nucl' && (preg_match('/\.[pn]al/', $blastdb_with_path) == 0)) {
+  $blastdb_with_suffix = $blastdb_with_path;
+  if ($mdb_type == 'nucl') {
     // Suffix may be .nsq or .nal
     if (is_readable("$blastdb_with_path.nsq")) {
       $blastdb_with_suffix = "$blastdb_with_path.nsq";
     }
-    else if (is_readable("$blastdb_with_path.nal")) {
+    elseif (is_readable("$blastdb_with_path.nal")) {
       $blastdb_with_suffix = "$blastdb_with_path.nal";
     }
   }
-  else if ($mdb_type == 'prot' && (preg_match('/\.[pn]al/', $blastdb_with_path) == 0)) {
+  elseif ($mdb_type == 'prot') {
     // Suffix may be .psq or .pal
     if (is_readable("$blastdb_with_path.psq")) {
       $blastdb_with_suffix = "$blastdb_with_path.psq";
@@ -495,9 +496,6 @@ function blast_ui_per_blast_program_form_submit($form, &$form_state) {
     else if (is_readable("$blastdb_with_path.pal")) {
       $blastdb_with_suffix = "$blastdb_with_path.pal";
     }
-  }
-  else {
-    $blastdb_with_suffix = $blastdb_with_path;
   }
 
   if (!is_readable($blastdb_with_suffix)) {

--- a/includes/blast_ui.node.inc
+++ b/includes/blast_ui.node.inc
@@ -285,6 +285,14 @@ function blastdb_form($node, &$form_state) {
 
 function blastdb_form_validate($form, $form_state) {
 
+  // Check the database path does not include the file format suffix.
+  $suffix = ['.ndb', '.nhr', '.nin', '.not', '.nsq', '.ntf', '.nto',
+    '.pdb', '.phr', '.pin', '.pot', '.psq', '.ptf', '.pto'];
+  foreach ($suffix as $ending) {
+    if (strpos($form_state['values']['db_path'], $ending) !== false) {
+      form_set_error('db_path', "You blast database path should not include the file type suffix. Specifically, remove '$ending'.");
+    }
+  }
   if (isset($form_state['values']['regex']) AND !empty($form_state['values']['regex'])) {
     // Check that any supplied regex includes //.
     if (!preg_match('/\/.*\//', $form_state['values']['regex'])) {
@@ -548,4 +556,3 @@ function blastdb_load($nodes) {
 function ajax_blast_ui_node_linkout_custom_callback($form, $form_state) {
   return $form['dbxref']['details'];
 }
-


### PR DESCRIPTION
In response to #77 

This PR updates the regex checking the file ending suffix to be extra cautious to only remove the expected suffix. Additionally, I added in validation to ensure the suffix is not included when the database is saved. Both are needed since `run_BLAST_tripal_job()` can be used as an API function without using BlastDB nodes. I also added a check that the database actually exists so a useful error can be output in this case.

## Testing
- Create a Blast Database node and include any of the following endings: '.ndb', '.nhr', '.nin', '.not', '.nsq', '.ntf', '.nto', '.pdb', '.phr', '.pin', '.pot', '.psq', '.ptf', '.pto'. You should receive a helpful validation error.
- Use `run_BLAST_tripal_job()` directly and supply a database with one of the above endings. It should be stripped.
- Use `run_BLAST_tripal_job()` directly and supply a database that does not exist. You should be given a helpful error message.

## Note
This will not allow people to use database names with one of the aforementioned endings in the name. This is what I intend.