### PR TITLE
Issue 93 $acc parameter no longer optional

### DIFF
--- a/api/blast_ui.api.inc
+++ b/api/blast_ui.api.inc
@@ -554,7 +554,10 @@ function sort_blast_jobs_by_date_submitted_desc($a, $b) {
  * @returm
  *    A base64 encoded image representing the hit information.
  */
-function generate_blast_hit_image($acc = '', $scores, $hits, $tsize, $qsize, $name, $hit_name) {
+function generate_blast_hit_image($acc, $scores, $hits, $tsize, $qsize, $name, $hit_name) {
+  if (!$acc) {
+    $acc = '';
+  }
   $tok = strtok($hits, ";");
   $b_hits = Array();
   while ($tok !== false) {


### PR DESCRIPTION
Simple fix for the PHP8 issue described in Issue #93 

Make the ```$acc``` parameter into a required parameter, move the assignment of null string into the code. Though I suspect this will never be needed, it will always have a value. But this way there is no possibility of a functional change.