### PR TITLE
Issue 95 php8 catching mismatched parameter names

### DIFF
--- a/includes/blast_ui.form_per_program.inc
+++ b/includes/blast_ui.form_per_program.inc
@@ -548,7 +548,7 @@ function blast_ui_per_blast_program_form_submit($form, &$form_state) {
       'program' => $blast_program,
       'query' => $blastjob['query_file'],
       'database' => $blastdb_with_path,
-      'output_filename' => $output_filestub,
+      'output_filestub' => $output_filestub,
       'options' => $advanced_options
     );
 


### PR DESCRIPTION
Issue #95 

This is a single-line fix to make the passed parameter name match the expected name for 
```function run_BLAST_tripal_job($program, $query, $database, $output_filestub, $options, $job_id = NULL)```