### PR TITLE
Add skeleton of docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 supervisord*
 .phpunit.*
+mkdocs/site

--- a/mkdocs/Dockerfile
+++ b/mkdocs/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-bookworm
+
+## Install mkdocs
+RUN pip install mkdocs mkdocs-material && mkdocs --version
+
+EXPOSE 8000
+
+## Setup our docs
+RUN mkdir tripal_blast
+COPY . /tripal_blast/
+WORKDIR /tripal_blast

--- a/mkdocs/docs/admin/blast-databases.md
+++ b/mkdocs/docs/admin/blast-databases.md
@@ -1,0 +1,7 @@
+
+# Managing BLAST databases
+
+!!! warning "Under Development"
+
+    This documentation is still being developed as this module is being upgraded.
+

--- a/mkdocs/docs/admin/config.md
+++ b/mkdocs/docs/admin/config.md
@@ -1,0 +1,7 @@
+
+# Configuring BLAST
+
+!!! warning "Under Development"
+
+    This documentation is still being developed as this module is being upgraded.
+

--- a/mkdocs/docs/admin/running-jobs.md
+++ b/mkdocs/docs/admin/running-jobs.md
@@ -1,0 +1,7 @@
+
+# Running jobs automatically
+
+!!! warning "Under Development"
+
+    This documentation is still being developed as this module is being upgraded.
+

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -1,0 +1,9 @@
+# Overview
+
+This module provides a basic interface to allow your users to utilize your server's NCBI BLAST+.
+
+Specifically it provides blast program-specific forms (blastn, blastp, tblastn, blastx are supported) where users can input their query sequence and choose from an admin configured list of available target databases to align their query sequence against.
+
+BLAST submissions result in the creation of Tripal jobs which then need to run from the command-line. This ensures that long running BLASTs will not cause page time-outs but does add some management overhead and might result in longer waits for users depending on how often you have cron set to run Tripal jobs.
+
+The BLAST results page is an expandable summary table with each hit being listed as a row in the table with query/hit/e-value information. The row can then be expanded to include additional information including the alignment. Download formats are allow users to download these results in the familiar tabular, GFF3 or HTML NCBI formats.

--- a/mkdocs/docs/install/composer-install.md
+++ b/mkdocs/docs/install/composer-install.md
@@ -1,0 +1,6 @@
+
+# Adding Tripal BLAST to an existing site via Composer
+
+!!! warning "Under Development"
+
+    This documentation is still being developed as this module is being upgraded.

--- a/mkdocs/docs/install/docker-demo.md
+++ b/mkdocs/docs/install/docker-demo.md
@@ -1,0 +1,6 @@
+
+# Trying out Tripal BLAST with Docker
+
+!!! warning "Under Construction"
+
+    This documentation is still being developed as this module is being upgraded.

--- a/mkdocs/docs/users/previous-requests.md
+++ b/mkdocs/docs/users/previous-requests.md
@@ -1,0 +1,7 @@
+
+# Finding previous requests
+
+!!! warning "Under Construction"
+
+    This documentation is still being developed as this module is being upgraded.
+

--- a/mkdocs/docs/users/result-page.md
+++ b/mkdocs/docs/users/result-page.md
@@ -1,0 +1,7 @@
+
+# BLAST result page
+
+!!! warning "Under Construction"
+
+    This documentation is still being developed as this module is being upgraded.
+

--- a/mkdocs/docs/users/submit-blast.md
+++ b/mkdocs/docs/users/submit-blast.md
@@ -1,0 +1,7 @@
+
+# Submitting a BLAST request
+
+!!! warning "Under Construction"
+
+    This documentation is still being developed as this module is being upgraded.
+

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -1,0 +1,100 @@
+site_name: Tripal BLAST Documentation
+site_url: https://tripal.github.io/tripal_blast
+site_author: Lacey-Anne Sanderson
+site_description: >-
+  Write your documentation in Markdown and create a professional static site in
+  minutes – searchable, customizable, in 60+ languages, for all devices
+
+# Repository
+repo_name: tripal/tripal_blast
+repo_url: https://github.com/tripal/tripal_blast
+
+# Copyright
+copyright: Copyright &copy; 2018 - 2024, Lacey-Anne Sanderson, University of Saskatchewan
+
+nav:
+  - Home: index.md
+  - Installation:
+    - Adding to an existing site: install/composer-install.md
+    - Demonstration via Docker: install/docker-demo.md
+  - Guiding your Users:
+    - Submitting a BLAST request: users/submit-blast.md
+    - Finding previous requests: users/previous-requests.md
+    - BLAST result page: users/result-page.md
+  - Site Administration:
+    - Configuring BLAST: admin/config.md
+    - Managing BLAST databases: admin/blast-databases.md
+    - Running jobs automatically: admin/running-jobs.md
+  # - Customization:
+  #   - Custom Link-outs
+  #   - Custom Styling
+
+# Extensions
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      normalize_issue_symbols: true
+      repo_url_shorthand: true
+      user: squidfunk
+      repo: mkdocs-material
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.snippets:
+      auto_append:
+        - includes/mkdocs.md
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+      combine_header_slug: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: green
+      accent: teal
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: green
+      accent: teal
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode


### PR DESCRIPTION
This PR adds a skeleton of documentation for this module (more a plan then actual documentation at this point) using [mkdocs](https://www.mkdocs.org/) and the [Material Theme](https://squidfunk.github.io/mkdocs-material/).

How to develop these docs:

```
cd docs
docker build --tag trpblast:docs ./
docker run --rm --volume=$(pwd):/tripal_blast trpblast:docs mkdocs build
open site/index.html
```

To see something like the following:
![image](https://github.com/tripal/tripal_blast/assets/1566301/9b09e9a7-90ea-4288-9233-8a4e6cfa4e46)
