### PR TITLE
Make some form elements optional for blast database setup

### DIFF
--- a/src/Form/TripalBlastDatabaseForm.php
+++ b/src/Form/TripalBlastDatabaseForm.php
@@ -87,7 +87,7 @@ class TripalBlastDatabaseForm extends EntityForm {
         '#type' => 'textfield',
         '#title' => $this->t('Extract Regular Expression'),
         '#description' => $this->t('The Regular Expression to use to extract the id from the FASTA header of the BLAST database hit.'),
-        '#required' => TRUE,
+        '#required' => FALSE,
         '#default_value' => $blast_db->getDbXrefRegExp()  
       ];
 
@@ -97,7 +97,7 @@ class TripalBlastDatabaseForm extends EntityForm {
         '#type' => 'textfield',
         '#title' => $this->t('BLAST database reference'),
         '#description' => $this->t('The Database records from this BLAST Database reference.'),
-        '#required' => TRUE,
+        '#required' => FALSE,
         '#default_value' => $blast_db->getDbXref()    
       ];
     
@@ -107,7 +107,7 @@ class TripalBlastDatabaseForm extends EntityForm {
         '#type' => 'textfield',
         '#title' => $this->t('BLAST database reference linkout type'),
         '#description' => $this->t('Type of linkout to be used for this database reference.'),
-        '#required' => TRUE,
+        '#required' => FALSE,
         '#default_value' => $blast_db->getDbXrefLinkout()    
       ];
           


### PR DESCRIPTION
**PR description updated based on issue**

Issue #111 

This PR makes a number of new settings focused on linkouts optional in the blast database entity form. These settings are not yet well described and thus not clear how to fill out. We will evaluate whether they need to be required at a later date once this module is more stable.

## Testing

Create a blast database through the UI and confirm you can leave these fields empty and the page is created without error.

![image](https://github.com/user-attachments/assets/951dedc6-518d-4fb2-8a1e-375e92301351)
