### PR TITLE
Adds Blast configuration to Tripal Extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.licenses=GPL-3.0-or-later
 COPY . /var/www/drupal/web/modules/contrib/tripal_blast
 
 ## Set correct config based on versions.
-RUN rm ./phpunit.xml
+RUN rm -f ./phpunit.xml
 RUN bash /var/www/drupal/web/modules/contrib/tripal/set_phpunit_config.sh
 
 ## Install NCBI Blast+.

--- a/tripal_blast.links.menu.yml
+++ b/tripal_blast.links.menu.yml
@@ -5,3 +5,9 @@ tripal_blast.blast_ui:
   parent: main
   route_name: tripal_blast.blast_ui
   menu_name: main
+
+tripal_blast.blast_ui_config:
+  title: Configure Tripal Cultivate Phenotypes Module
+  description: 'Queries to existing BLAST databases.'
+  parent: tripal.extension
+  route_name: entity.tripal_blast.blast_database

--- a/tripal_blast.links.menu.yml
+++ b/tripal_blast.links.menu.yml
@@ -6,8 +6,32 @@ tripal_blast.blast_ui:
   route_name: tripal_blast.blast_ui
   menu_name: main
 
-tripal_blast.blast_config:
-  title: Configure Tripal BLAST Module
-  description: 'Manage all Tripal BLAST-related configurations.'
-  parent: tripal.extension
-  route_name: tripal_blast.configuration
+# Menu - Configuring Tripal BLAST.
+# Group in admin/tripal/extension
+tripal_blast.menu:
+  title: 'Tripal BLAST Module'
+  description: 'Access all the Tripal BLAST related configuration pages.'
+  route_name: 'tripal_blast.dashboard'
+  parent: 'tripal.extension'
+  weight: 0
+
+tripal_blast.configuration:
+  title: 'Tripal Blast: Configuration'
+  description: 'Manage all the Tripal BLAST-related configurations.'
+  route_name: 'tripal_blast.configuration'
+  parent: 'tripal_blast.menu'
+  weight: 1
+
+tripal_blast.blast_databases:
+  title: 'Tripal BLAST UI'
+  description: 'Manage all Tripal BLAST database entities.'
+  parent: 'tripal_blast.menu'
+  route_name: 'entity.tripal_blast.blast_database'
+  weight: 2
+
+tripal_blast.help:
+  title: 'Tripal Blast: Help'
+  description: 'Contains the help content for the Tripal BLAST module.'
+  route_name: 'tripal_blast.help'
+  parent: 'tripal_blast.menu'
+  weight: 3

--- a/tripal_blast.links.menu.yml
+++ b/tripal_blast.links.menu.yml
@@ -6,8 +6,8 @@ tripal_blast.blast_ui:
   route_name: tripal_blast.blast_ui
   menu_name: main
 
-tripal_blast.blast_ui_config:
+tripal_blast.blast_config:
   title: Configure Tripal BLAST Module
-  description: 'Queries to existing BLAST databases.'
+  description: 'Manage all Tripal BLAST-related configurations.'
   parent: tripal.extension
-  route_name: entity.tripal_blast.blast_database
+  route_name: tripal_blast.configuration

--- a/tripal_blast.links.menu.yml
+++ b/tripal_blast.links.menu.yml
@@ -23,7 +23,7 @@ tripal_blast.configuration:
   weight: 1
 
 tripal_blast.blast_databases:
-  title: 'Tripal BLAST UI'
+  title: 'Tripal BLAST Databases'
   description: 'Management of Tripal BLAST query databases.'
   parent: 'tripal_blast.menu'
   route_name: 'entity.tripal_blast.blast_database'

--- a/tripal_blast.links.menu.yml
+++ b/tripal_blast.links.menu.yml
@@ -24,7 +24,7 @@ tripal_blast.configuration:
 
 tripal_blast.blast_databases:
   title: 'Tripal BLAST UI'
-  description: 'Manage all Tripal BLAST database entities.'
+  description: 'Management of Tripal BLAST query databases.'
   parent: 'tripal_blast.menu'
   route_name: 'entity.tripal_blast.blast_database'
   weight: 2

--- a/tripal_blast.links.menu.yml
+++ b/tripal_blast.links.menu.yml
@@ -10,7 +10,7 @@ tripal_blast.blast_ui:
 # Group in admin/tripal/extension
 tripal_blast.menu:
   title: 'Tripal BLAST Module'
-  description: 'Access all the Tripal BLAST related configuration pages.'
+  description: 'Access all Tripal BLAST-related configuration.'
   route_name: 'tripal_blast.dashboard'
   parent: 'tripal.extension'
   weight: 0

--- a/tripal_blast.links.menu.yml
+++ b/tripal_blast.links.menu.yml
@@ -7,7 +7,7 @@ tripal_blast.blast_ui:
   menu_name: main
 
 tripal_blast.blast_ui_config:
-  title: Configure Tripal Cultivate Phenotypes Module
+  title: Configure Tripal BLAST Module
   description: 'Queries to existing BLAST databases.'
   parent: tripal.extension
   route_name: entity.tripal_blast.blast_database

--- a/tripal_blast.links.menu.yml
+++ b/tripal_blast.links.menu.yml
@@ -17,7 +17,7 @@ tripal_blast.menu:
 
 tripal_blast.configuration:
   title: 'Tripal Blast: Configuration'
-  description: 'Manage all the Tripal BLAST-related configurations.'
+  description: 'Configuration settings for all Tripal BLAST forms.'
   route_name: 'tripal_blast.configuration'
   parent: 'tripal_blast.menu'
   weight: 1

--- a/tripal_blast.links.menu.yml
+++ b/tripal_blast.links.menu.yml
@@ -31,7 +31,7 @@ tripal_blast.blast_databases:
 
 tripal_blast.help:
   title: 'Tripal Blast: Help'
-  description: 'Contains the help content for the Tripal BLAST module.'
+  description: 'Support for setting up NCBI BLAST+ and more.'
   route_name: 'tripal_blast.help'
   parent: 'tripal_blast.menu'
   weight: 3

--- a/tripal_blast.routing.yml
+++ b/tripal_blast.routing.yml
@@ -35,6 +35,14 @@ tripal_blast.blast_report:
   requirements:
     _permission: 'access content'
 
+# Configuration dashboard.
+tripal_blast.dashboard:
+  path: 'admin/tripal/extension/tripal_blast'
+  defaults:
+    _title: 'Tripal BLAST'
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+  requirements:
+    _permission: 'administer tripal'
 
 # Routes below are for configuration and help.
 # Uses tabs @see tripal_blast.link.task.yml.
@@ -59,7 +67,7 @@ tripal_blast.help:
 # Route set below defines routes for the management of
 # configuration entity (list, add, edit and delete).
 entity.tripal_blast.blast_database:
-  path: '/admin/tripal/extension/tripal_blast'
+  path: '/admin/tripal/extension/tripal_blast/databases'
   defaults:
     _entity_list: 'tripalblastdatabase'
     _title: 'Tripal BLAST UI'
@@ -67,7 +75,7 @@ entity.tripal_blast.blast_database:
     _permission: 'administer tripal,_access_admin_menu_block_page'
 
 entity.tripal_blast.blast_database.add:
-  path: '/admin/tripal/extension/tripal_blast/add'
+  path: '/admin/tripal/extension/tripal_blast/databases/add'
   defaults:
     _entity_form: 'tripalblastdatabase.add'
     _title: 'Tripal BLAST Add Query Database'
@@ -75,7 +83,7 @@ entity.tripal_blast.blast_database.add:
     _permission: 'administer tripal'
 
 entity.tripalblastdatabase.edit_form:
-  path: '/admin/tripal/extension/tripal_blast/edit/{tripalblastdatabase}'
+  path: '/admin/tripal/extension/tripal_blast/databases/edit/{tripalblastdatabase}'
   defaults:
     _entity_form: 'tripalblastdatabase.edit'
     _title: 'Tripal BLAST Edit Query Database'
@@ -83,7 +91,7 @@ entity.tripalblastdatabase.edit_form:
     _permission: 'administer tripal'
 
 entity.tripalblastdatabase.delete_form:
-  path: '/admin/tripal/extension/tripal_blast/delete/{tripalblastdatabase}'
+  path: '/admin/tripal/extension/tripal_blast/databases/delete/{tripalblastdatabase}'
   defaults:
     _entity_form: 'tripalblastdatabase.delete'
     _title: 'Tripal BLAST Delete Query Database'

--- a/tripal_blast.routing.yml
+++ b/tripal_blast.routing.yml
@@ -48,7 +48,7 @@ tripal_blast.configuration:
     _permission: 'administer tripal'
 
 tripal_blast.help:
-  path: '/admin/tripal/extension/tripal_blast/configuration/help'
+  path: '/admin/tripal/extension/tripal_blast/help'
   defaults:
     _title: 'Tripal Blast: Help'
     _controller: '\Drupal\tripal_blast\Controller\TripalBlastHelpController::help'
@@ -89,4 +89,3 @@ entity.tripalblastdatabase.delete_form:
     _title: 'Tripal BLAST Delete Query Database'
   requirements:
     _permission: 'administer tripal'
-


### PR DESCRIPTION
Added the Blast configuration to Tripal Extensions listing.


## Testing

1. Build a clone on this branch and Login as an admin.
2. Navigate to Tripal > Extensions > Tripal Blast Module
<img width="854" height="634" alt="Screenshot 2026-07-16 at 4 14 36 PM" src="https://github.com/user-attachments/assets/78682988-35e6-4e6e-9ee6-45c64cd35f59" />
3. Once you click on Tripal Blast Module, the following page should appear.
<img width="947" height="488" alt="Screenshot 2026-07-16 at 4 14 52 PM" src="https://github.com/user-attachments/assets/83460a30-45e8-4c85-8b3b-15a5d634e284" />
4. Click on each link to test whether they are directed to the correct page. 
