### PR TITLE
Add test coverage for Blast Submission Form across all 4 programs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.licenses=GPL-3.0-or-later
 COPY . /var/www/drupal/web/modules/contrib/tripal_blast
 
 ## Set correct config based on versions.
-RUN rm ./phpunit.xml
+RUN rm -f ./phpunit.xml
 RUN bash /var/www/drupal/web/modules/contrib/tripal/set_phpunit_config.sh
 
 ## Install NCBI Blast+.

--- a/src/Form/TripalBlastForm.php
+++ b/src/Form/TripalBlastForm.php
@@ -169,10 +169,8 @@ class TripalBlastForm extends FormBase {
         '#type' => 'details',
         '#title' => $this->t('Enter %type Query Sequence', ['%type' => $query]),
         '#open' => TRUE,
-        '#description' => $this->t('Enter one or more queries in the top text box or
-          use the browse button to upload a file from your local disk. The file
-          may contain a single sequence or a list of sequences. In both cases,
-          the data must be in <a href="@formaturl">FASTA format</a>.',
+        '#description' => $this->t('Enter one or more queries in the top text box. It
+          may contain a single sequence or a list of sequences and the data must be in <a href="@formaturl">FASTA format</a>.',
           ['@formaturl' => 'http://www.ncbi.nlm.nih.gov/BLAST/blastcgihelp.shtml']),
       ];
 

--- a/src/Form/TripalBlastForm.php
+++ b/src/Form/TripalBlastForm.php
@@ -6,15 +6,13 @@
 
 namespace Drupal\tripal_blast\Form;
 
-use Drupal\Core\Form\FormBase;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\InvokeCommand;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\file\Entity\File;
-use Drupal\node\Entity\Node;
-use Drupal\tripal\Services\TripalJob;
 use Drupal\tripal_blast\Services\TripalBlastProgramHelper;
 
 /**

--- a/src/Form/TripalBlastForm.php
+++ b/src/Form/TripalBlastForm.php
@@ -348,7 +348,7 @@ class TripalBlastForm extends FormBase {
           (.fasta, .fna, .fa, .fas) file. In other words, it cannot have formatting as is the
           case with MS Word (.doc, .docx) or Rich Text Format (.rtf). It cannot be greater
           than %max_size in size. <strong>Don\'t forget to press the Upload button before
-          attempting to submit your BLAST.</strong>', ['@max_size' => round($file_upload_max_size / 1024 / 1024,1) . 'MB']));
+          attempting to submit your BLAST.</strong>', ['%max_size' => round($file_upload_max_size / 1024 / 1024,1) . 'MB']));
       }
     }
     else {

--- a/src/Form/TripalBlastForm.php
+++ b/src/Form/TripalBlastForm.php
@@ -12,10 +12,7 @@ use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\InvokeCommand;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-
 use Drupal\tripal\Services\TripalJob;
-
 use Drupal\tripal_blast\Services\TripalBlastProgramHelper;
 
 /**
@@ -434,7 +431,7 @@ class TripalBlastForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $error = FALSE;
     $query_type = $form_state->getValue('query_type');
-    $db_type = $form_state->getValue('$db_type');
+    $db_type = $form_state->getValue('db_type');
     $mdb_type = ($db_type == 'nucleotide') ? 'nucl' : 'prot';
 
     // Let's start by collecting the information from the form submission.
@@ -551,10 +548,10 @@ class TripalBlastForm extends FormBase {
       // manually, look into setting up a cron job to launch the tripal jobs
       // on a specified schedule.
 
-      // Redirect to the BLAST results page
+      // Redirect to the BLAST results page using form redirection (no direct send).
       $go = '/blast/report/' . $job_encode_id;
-      $redirect = new RedirectResponse(Url::fromUserInput($go)->toString());
-      $redirect->send();
+      $url = Url::fromUserInput($go);
+      $form_state->setRedirectUrl($url);
     }
   }
 

--- a/src/Form/TripalBlastForm.php
+++ b/src/Form/TripalBlastForm.php
@@ -10,7 +10,9 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\InvokeCommand;
+use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Drupal\file\Entity\File;
 use Drupal\node\Entity\Node;
 use Drupal\tripal\Services\TripalJob;
 use Drupal\tripal_blast\Services\TripalBlastProgramHelper;
@@ -324,7 +326,7 @@ class TripalBlastForm extends FormBase {
     $fld_file_query_value = $form_state->getValue('UPLOAD');
 
     if($fld_file_query_value) {
-      $file = file_load($fld_file_query_value);
+      $file = File::load($fld_file_query_value);
     }
 
     $fld_fasta_value = $form_state->getValue('FASTA');
@@ -332,7 +334,7 @@ class TripalBlastForm extends FormBase {
       // If the $file is populated then this a newly uploaded, temporary file.
       $form_state->setValue('qFlag', 'upQuery');
 
-      $file_uri = \Drupal::service('file_system')->realpath($file->uri);
+      $file_uri = $file->getFileUri();
       $form_state->setValue('upQuery_path', $file_uri);
     }
     elseif (!empty($fld_fasta_value)) {
@@ -369,13 +371,13 @@ class TripalBlastForm extends FormBase {
     $fld_select_db_value = $form_state->getValue('SELECT_DB');
 
     if ($fld_file_db_value) {
-      $file = file_load($fld_file_db_value);
+      $file = File::load($fld_file_db_value);
 
       if (is_object($file)) {
         // If the $file is populated then this is a newly uploaded, temporary file.
         $form_state->setValue('dbFlag', 'upDB');
 
-        $file_uri = \Drupal::service('file_system')->realpath($file->uri);
+        $file_uri = $file->getFileUri();
         $form_state->setValue('upDB_path', $file_uri);
       }
       elseif (empty($fld_select_db_value)) {
@@ -517,6 +519,8 @@ class TripalBlastForm extends FormBase {
 
     $blast_submission['options'] = $advanced_options;
 
+    $job_id = NULL;
+
     // SUBMIT JOB TO TRIPAL
     //---------------------
     // If there is a blast target...
@@ -593,7 +597,7 @@ class TripalBlastForm extends FormBase {
       $fld_value = $sequence_example;
 
       // Add a note to user, default example may be replaced through the admin interface.
-      $l = \Drupal::l('administartive interface', Url::fromRoute('tripal_blast.configuration'));
+      $l = Link::fromTextAndUrl('administrative interface', Url::fromRoute('tripal_blast.configuration'))->toString();
       $fld_note = '<div class="tripal-blast-tip">'
         . $this->t('You can set the example sequence through the @note.', ['@note' => $l])
         . '</div>';

--- a/src/Form/TripalBlastForm.php
+++ b/src/Form/TripalBlastForm.php
@@ -127,7 +127,7 @@ class TripalBlastForm extends FormBase {
       }
 
       // Finally save the previous blast details for use by the advanced option forms.
-      $form_state['prev_blast'] = $prev_blast;
+      $form_state->setValue('prev_blast', $prev_blast);
     }
 
 

--- a/src/Services/TripalBlastProgramHelper.php
+++ b/src/Services/TripalBlastProgramHelper.php
@@ -214,8 +214,8 @@ class TripalBlastProgramHelper {
    */
   public static function programSetMatchMismatch($mm_score) {
     // Defaults in case an unexpected value is passed.
-    $penalty = -2;
-    $reward = 1;
+    $penalty = '';
+    $reward = '';
 
     switch ($mm_score) {
       case 0:

--- a/src/Services/TripalBlastProgramHelper.php
+++ b/src/Services/TripalBlastProgramHelper.php
@@ -213,6 +213,10 @@ class TripalBlastProgramHelper {
    *   Match and mismatch value.
    */
   public static function programSetMatchMismatch($mm_score) {
+    // Defaults in case an unexpected value is passed.
+    $penalty = -2;
+    $reward = 1;
+
     switch ($mm_score) {
       case 0:
         $penalty = -2;

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -675,6 +675,8 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'gapCost' => '5,2',
     ]);
     $this->blast_form->submitForm($form, $form_state);
+
+    $this->assertNotNull($form_state->getRedirect());
   }
 
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\tripal_blast\Kernel;
 
+use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Form\FormState;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\tripal_blast\Traits\TripalBlastTestTrait;
@@ -314,4 +315,43 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       $this->assertSame($before + 1, $after, 'Submission did not create a job record for ' . $program['program']);
     }
   }
+
+  /**
+   * Tests buildForm covers warning, recent-job, and resubmit defaults.
+   */
+  public function testBuildFormCoversWarningsRecentJobsAndResubmitDefaults(): void {
+    $editable_config = \Drupal::service('config.factory')->getEditable('tripal_blast.settings');
+    $editable_config->set('tripal_blast_config_notification.warning_text', 'Temporary maintenance warning');
+    $editable_config->set('tripal_blast_config_sequence.nucleotide', '>example\nACGT');
+    $editable_config->save();
+
+    $query_file = $this->container->get('file_system')->getTempDirectory() . '/resubmit_query.fasta';
+    file_put_contents($query_file, ">query\nACGT");
+
+    $job_service = $this->getMockBuilder(\Drupal\tripal_blast\Services\TripalBlastJobService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['jobsCountRecentJobs', 'jobsCreateTable', 'jobsBlastRevealSecret', 'jobsGetJobByJobId'])
+      ->getMock();
+    $job_service->method('jobsCountRecentJobs')->willReturn(1);
+    $job_service->method('jobsCreateTable')->willReturn(['#type' => 'table']);
+    $job_service->method('jobsBlastRevealSecret')->willReturn(42);
+    $job_service->method('jobsGetJobByJobId')->willReturn((object) [
+      'blastdb' => (object) ['nid' => 99],
+      'files' => (object) ['query' => $query_file],
+    ]);
+    $this->container->set('tripal_blast.job_service', $job_service);
+
+    \Drupal::request()->query->set('resubmit', 'secret-id');
+
+    $form = [];
+    $form_state = new FormState();
+    $build = $this->blast_form->buildForm($form, $form_state, 'nucleotide', 'nucleotide');
+
+    $this->assertArrayHasKey('config_warning', $build);
+    $this->assertArrayHasKey('A', $build);
+    $this->assertSame('table', $build['A']['recent_job']['#type']);
+    $this->assertSame(99, $build['B']['db']['SELECT_DB']['#default_value']);
+    $this->assertSame(">query\nACGT", $build['B']['query']['FASTA']['#default_value']);
+  }
+
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -182,7 +182,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'maxTarget' => '50',
           'eVal' => '1e-5',
           'wordSize' => '11',
-          'M&MScores' => '1,-2',
+          'M&MScores' => 0,
           'gapCost' => '5,2',
         ],
         [
@@ -200,7 +200,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'maxTarget' => '500',
           'eVal' => '1e-5',
           'wordSize' => '11',
-          'M&MScores' => '1,-2',
+          'M&MScores' => 0,
           'gapCost' => '5,2',
         ],
         [
@@ -270,7 +270,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'maxTarget' => '500',
           'eVal' => '1e-5',
           'wordSize' => '11',
-          'M&MScores' => '1,-2',
+          'M&MScores' => 0,
           'gapCost' => '5,2',
         ],
         [
@@ -288,7 +288,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'maxTarget' => '500',
           'eVal' => '1e-5',
           'wordSize' => '11',
-          'M&MScores' => '1,-2',
+          'M&MScores' => 0,
           'gapCost' => '5,2',
         ],
         [
@@ -310,7 +310,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'maxTarget' => '500',
           'eVal' => '1e-5',
           'wordSize' => '11',
-          'M&MScores' => '1,-2',
+          'M&MScores' => 0,
           'gapCost' => '5,2',
         ],
         [
@@ -331,7 +331,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'maxTarget' => '500',
           'eVal' => '1e-5',
           'wordSize' => '11',
-          'M&MScores' => '1,-2',
+          'M&MScores' => 0,
           'gapCost' => '5,2',
         ],
         [
@@ -351,7 +351,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'maxTarget' => '500',
           'eVal' => 'not-a-number',
           'wordSize' => '11',
-          'M&MScores' => '1,-2',
+          'M&MScores' => 0,
           'gapCost' => '5,2',
         ],
         [
@@ -430,7 +430,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'maxTarget' => '500',
           'eVal' => '1e-5',
           'wordSize' => '11',
-          'M&MScores' => '1,-2',
+          'M&MScores' => 0,
           'gapCost' => '5,2',
         ],
       ],
@@ -471,7 +471,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'maxTarget' => '500',
           'eVal' => '1e-5',
           'wordSize' => '11',
-          'M&MScores' => '1,-2',
+          'M&MScores' => 1,
           'gapCost' => '5,2',
         ],
       ],
@@ -606,7 +606,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'maxTarget' => '500',
       'eVal' => '1e-5',
       'wordSize' => '11',
-      'M&MScores' => '1,-2',
+      'M&MScores' => 0,
       'gapCost' => '5,2',
     ]);
 
@@ -657,7 +657,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'maxTarget' => '500',
       'eVal' => '1e-5',
       'wordSize' => '11',
-      'M&MScores' => '1,-2',
+      'M&MScores' => 0,
       'gapCost' => '5,2',
     ]);
     $this->blast_form->submitForm($form, $form_state);
@@ -689,7 +689,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'maxTarget' => '500',
       'eVal' => '1e-5',
       'wordSize' => '11',
-      'M&MScores' => '1,-2',
+      'M&MScores' => 0,
       'gapCost' => '5,2',
     ]);
 
@@ -720,7 +720,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'query_type' => 'nucleotide',
       'example_sequence' => TRUE,
       'blast_program' => 'blastn',
-      'M&MScores' => '1,-2',
+      'M&MScores' => 0,
     ]);
 
     $updated_form = $this->blast_form->ajaxShowExampleSequenceCallback($form, $form_state);
@@ -730,6 +730,249 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $response = $this->blast_form->ajaxFieldUpdateCallback($form, $form_state);
     $this->assertInstanceOf(AjaxResponse::class, $response);
     $this->assertNotEmpty($response->getCommands(), 'Expected the AJAX response to contain commands but it does not.');
+  }
+
+  /**
+   * Provides data for testing the gap cost retrieval in the AJAX callback.
+   *
+   * @return array
+   */
+  public static function provideDataForTestProgamGetGapCostInAjaxCallback(): array {
+    return [
+      'blastn with m&m score 0' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'M&MScores' => 0,
+        ],
+        [
+          'gap_keys' => ['5_2', '2_2', '1_2', '0_2', '3_1', '2_1', '1_1'],
+        ],
+      ],
+      'blastn with m&m score 1' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'M&MScores' => 1,
+        ],
+        [
+          'gap_keys' => ['5_2', '2_2', '1_2', '1_2', '0_2', '2_1', '1_1'],
+        ],
+      ],
+      'blastn with m&m score 2' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'M&MScores' => 2,
+        ],
+        [
+          'gap_keys' => ['5_2', '1_2', '0_2', '2_1', '1_1'],
+        ],
+      ],
+      'blastn with m&m score 3' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'M&MScores' => 3,
+        ],
+        [
+          'gap_keys' => ['4_4', '2_4', '0_4', '3_3', '6_2', '5_2', '4_2', '2_2'],
+        ],
+      ],
+      'blastn with m&m score 4' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'M&MScores' => 4,
+        ],
+        [
+          'gap_keys' => ['12_8', '6_5', '5_5', '4_5', '3_5'],
+        ],
+      ],
+      'blastn with m&m score 5' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'M&MScores' => 5,
+        ],
+        [
+          'gap_keys' => ['5_2', '3_2', '2_2', '1_2', '0_2', '4_1', '3_1', '2_1']
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Tests that the AJAX callback correctly retrieves the gap cost based on the program and M&M score.
+   *
+   * @param array $data
+   *   The form values to test the AJAX callback with.
+   *
+   * @dataProvider provideDataForTestProgamGetGapCostInAjaxCallback
+   */
+  #[DataProvider('provideDataForTestProgamGetGapCostInAjaxCallback')]
+  public function testProgamGetGapCostInAjaxCallback(array $data, array $result): void {
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues($data);
+
+    $response = $this->blast_form->ajaxFieldUpdateCallback($form, $form_state);
+
+    $this->assertInstanceOf(AjaxResponse::class, $response);
+    $this->assertNotEmpty($response->getCommands(), 'Expected the AJAX response to contain commands but it does not.');
+
+    $gaps = $response->getCommands()[0]['args'][0];
+
+    foreach ($result['gap_keys'] as $expected_gap) {
+      $this->assertArrayHasKey($expected_gap, $gaps, 'Expected gap cost ' . $expected_gap . ' to be present in the AJAX response but it is not.');
+    }
+  }
+
+  public static function provideDataForTestBlastProgramHelperProgramSetMatchMiss(): array {
+    return [
+      'blastn with m&m score 0' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '123450',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => 0,
+        ],
+        [
+          'match_miss' => [1, -2],
+        ],
+      ],
+      'blastn with m&m score 1' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '123450',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => 1,
+        ],
+        [
+          'match_miss' => [1, -3],
+        ],
+      ],
+      'blastn with m&m score 2' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '123450',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => 2,
+        ],
+        [
+          'match_miss' => [1, -4],
+        ],
+      ],
+      'blastn with m&m score 3' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '123450',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => 3,
+        ],
+        [
+          'match_miss' => [2, -3],
+        ],
+      ],
+      'blastn with m&m score 4' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '123450',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => 4,
+        ],
+        [
+          'match_miss' => [4, -5],
+        ],
+      ],
+      'blastn with m&m score 5' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '123450',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => 5,
+        ],
+        [
+          'match_miss' => [1, -1],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Tests that the BLAST program helper correctly sets match and mismatch scores based on the M&M score.
+   *
+   * @param array $data
+   *   The form values to test the BLAST program helper with.
+   * @param array $result
+   *   The expected match and mismatch scores.
+   *
+   * @dataProvider provideDataForTestBlastProgramHelperProgramSetMatchMiss
+   */
+  #[DataProvider('provideDataForTestBlastProgramHelperProgramSetMatchMiss')]
+  public function testBlastProgramHelperProgramSetMatchMiss(array $data, array $result): void {
+    $captured_submission = NULL;
+
+    $job_service = $this->getMockBuilder(\Drupal\tripal_blast\Services\TripalBlastJobService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['createBlastJob', 'jobsBlastMakeSecret'])
+      ->getMock();
+
+    $job_service->expects($this->once())
+      ->method('createBlastJob')
+      ->willReturnCallback(function (array $submission) use (&$captured_submission): int {
+        $captured_submission = $submission;
+        return 2024;
+      });
+
+    $job_service->method('jobsBlastMakeSecret')->willReturn('encoded-job');
+    $this->container->set('tripal_blast.job_service', $job_service);
+
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues($data);
+
+    $this->blast_form->submitForm($form, $form_state);
+
+    $this->assertIsArray($captured_submission['options']);
+    $this->assertSame($result['match_miss'][1], $captured_submission['options']['penalty'], "The penalty should be {$result['match_miss'][1]} but it was {$captured_submission['options']['penalty']}");
+    $this->assertSame($result['match_miss'][0], $captured_submission['options']['reward'], "The penalty should be {$result['match_miss'][0]} but it was {$captured_submission['options']['reward']}");
   }
 
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -646,7 +646,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
   /**
    * Tests that submitForm correctly handles the query flag.
    */
-  public function testSubmitFormQueryFlag() :void {
+  public function testSubmitFormQueryFlag(): void {
     $editable_config = \Drupal::service('config.factory')->getEditable('tripal_blast.settings');
     $editable_config->set('tripal_blast_config_general.path', 'tmp/true');
     $editable_config->save();
@@ -665,6 +665,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'query_type' => 'nucleotide',
       'db_type' => 'nucleotide',
       'qFlag' => 'upQuery',
+      'upQuery_path' => $nucleotide_db->getPath(),
       'FASTA' => ">seq\nACGT",
       'SELECT_DB' => (string) $nucleotide_db->getId(),
       'maxTarget' => '500',

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -4,10 +4,13 @@ namespace Drupal\Tests\tripal_blast\Kernel;
 
 use Drupal\Core\Form\FormState;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\Tests\tripal_blast\Traits\TripalBlastTestTrait;
 use Drupal\tripal_blast\Form\TripalBlastForm;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use Drupal\Tests\tripal\Traits\TripalTestTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 
 /**
  * Tests the Tripal BLAST form.
@@ -19,11 +22,24 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 #[Group('tripal-blast')]
 #[RunTestsInSeparateProcesses]
 class TripalBlastFormTest extends ChadoTestKernelBase {
+  use TripalBlastTestTrait;
+  use UserCreationTrait;
+  use TripalTestTrait;
 
   /**
    * {@inheritdoc}
    */
-  protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_chado','tripal_blast'];
+  protected static $modules = [
+    'system',
+    'user',
+    'path',
+    'path_alias',
+    'views',
+    'file',
+    'tripal',
+    'tripal_chado',
+    'tripal_blast',
+  ];
 
   /**
    * Class instance of the Tripal Blast Form.
@@ -31,6 +47,13 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
    * @var \Drupal\tripal_blast\Form\TripalBlastForm
    */
   protected $blast_form;
+
+  /**
+   * The path to tripal_blast module.
+   *
+   * @var string
+   */
+  private $module_path;
 
   /**
    * A Database query interface for querying Chado using Tripal DBX.
@@ -48,11 +71,25 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     // Create a test chado instance as needed by our service.
     $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+    $this->container->set('tripal_chado.database', $this->chado_connection);
 
-    $this->installConfig(['tripal_blast', 'system']);
+    $this->installConfig(['tripal_blast', 'system', 'tripal_chado']);
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('tripal', ['tripal_jobs']);
     $this->installSchema('tripal_blast', ['blastjob']);
+    $this->installSchema('tripal_chado', ['tripal_custom_tables']);
+    $this->installEntitySchema('file');
+    $this->installSchema('file', ['file_usage']);
+    $this->installEntitySchema('user');
+
+    // Create and log-in a user.
+    $this->setUpCurrentUser();
 
     $this->blast_form = TripalBlastForm::create($this->container);
+
+    $this->module_path = $this->container->get('module_handler')
+      ->getModule('tripal_blast')
+      ->getPath();
   }
 
   /**
@@ -201,4 +238,80 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     }
   }
 
+  /**
+   * Tests that form submission creates a BLAST job record for each program.
+   */
+  public function testSubmitFormCreatesJobRecordForAllBlastPrograms(): void {
+    $programs = [
+      ['query' => 'nucleotide', 'db' => 'nucleotide', 'program' => 'blastn'],
+      ['query' => 'nucleotide', 'db' => 'protein', 'program' => 'blastx'],
+      ['query' => 'protein', 'db' => 'nucleotide', 'program' => 'tblastn'],
+      ['query' => 'protein', 'db' => 'protein', 'program' => 'blastp'],
+    ];
+
+    $editable_config = \Drupal::service('config.factory')->getEditable('tripal_blast.settings');
+    $editable_config->set('tripal_blast_config_general.path', 'tmp/true');
+    $editable_config->save();
+
+    $fixture_dir = $this->module_path . '/tests/fixtures/Chlamydomonas_reinhardtii_v5.6';
+    $nucleotide_db = $this->createBlastDatabase([
+      'id' => 123450,
+      'name' => 'Fixture nucleotide BLAST DB',
+      'path' => $fixture_dir . '/Chlamydomonas_reinhardtii_v5.6.nin',
+      'dbtype' => 'n',
+    ]);
+    $protein_db = $this->createBlastDatabase([
+      'id' => 67890,
+      'name' => 'Fixture protein BLAST DB',
+      'path' => $fixture_dir . '/Chlamydomonas_reinhardtii_v5.6_protein.nin',
+      'dbtype' => 'p',
+    ]);
+
+    foreach ($programs as $program) {
+      $form = [];
+      $form_state = new FormState();
+      $selected_db_id = ($program['db'] === 'protein') ? $protein_db->getId() : $nucleotide_db->getId();
+
+      if ($program['program'] == 'blastn') {
+        $form_state->setValues([
+          'blast_program' => $program['program'],
+          'query_type' => $program['query'],
+          'db_type' => $program['db'],
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => (string) $selected_db_id,
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ]);
+      } else {
+        $form_state->setValues([
+          'blast_program' => $program['program'],
+          'query_type' => $program['query'],
+          'db_type' => $program['db'],
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => (string) $selected_db_id,
+        ]);
+      }
+
+      $this->blast_form->validateForm($form, $form_state);
+
+      $before = (int) $this->chado_connection->select('blastjob')
+        ->condition('blast_program', $program['program'])
+        ->countQuery()
+        ->execute()
+        ->fetchField();
+
+      $this->blast_form->submitForm($form, $form_state);
+
+      $after = (int) \Drupal::database()->select('blastjob')
+        ->condition('blast_program', $program['program'])
+        ->countQuery()
+        ->execute()
+        ->fetchField();
+
+      $this->assertSame($before + 1, $after, 'Submission did not create a job record for ' . $program['program']);
+    }
+  }
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -106,7 +106,11 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
    * Provides data for testBuildForm.
    *
    * @return array
-   *   An array of test scenarios, each containing query type, database type, and expected program.
+   *   An array of test scenarios, each containing query type, database type, expected program and expected title.
+   *   - query_type: The type of the query (nucleotide or protein).
+   *   - db_type: The type of the database (nucleotide or protein).
+   *   - expected_program: The expected BLAST program based on the query and database types.
+   *   - expected_title: The expected title of the current BLAST program based on the query and database types.
    */
   public static function provideDataForTestBuildForm(): array {
     return [
@@ -115,13 +119,15 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'query_type' => 'nucleotide',
           'db_type' => 'nucleotide',
           'expected_program' => 'blastn',
+          'expected_title' => 'Nucleotide to Nucleotide BLAST (blastn)',
         ],
       ],
       'nucleotide blastx' => [
         [
-        'query_type' => 'nucleotide',
-        'db_type' => 'protein',
-        'expected_program' => 'blastx',
+          'query_type' => 'nucleotide',
+          'db_type' => 'protein',
+          'expected_program' => 'blastx',
+          'expected_title' => 'Nucleotide to Protein BLAST (blastx)',
         ],
       ],
       'protein tblastn' => [
@@ -129,6 +135,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'query_type' => 'protein',
           'db_type' => 'nucleotide',
           'expected_program' => 'tblastn',
+          'expected_title' => 'Protein to Nucleotide BLAST (tblastn)',
         ],
       ],
       'protein blastp' => [
@@ -136,6 +143,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'query_type' => 'protein',
           'db_type' => 'protein',
           'expected_program' => 'blastp',
+          'expected_title' => 'Protein to Protein BLAST (blastp)',
         ],
       ],
     ];
@@ -156,9 +164,21 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $build = $this->blast_form->buildForm($form, $form_state, $scenario['query_type'], $scenario['db_type']);
 
+    // Test if the correct title is created.
+    $page_title = [
+      '@query' => ucfirst($scenario['query_type']),
+      '@program' => ucfirst($scenario['db_type']),
+      '@name' => $scenario['expected_program'],
+    ];
+    $title = $this->container->get('string_translation')->translate('@query to @program BLAST (@name)', $page_title);
+    $this->assertEquals($scenario['expected_title'],(string) $title);
+
+    // Test if correct hidden elements are present.
     $this->assertSame($scenario['query_type'], $build['query_type']['#value'], 'We expect the query type to be ' . $scenario['query_type'] . ' but it is not.');
     $this->assertSame($scenario['db_type'], $build['db_type']['#value'], 'We expect the database type to be ' . $scenario['db_type'] . ' but it is not.');
     $this->assertSame($scenario['expected_program'], $build['blast_program']['#value'], 'We expect the BLAST program to be ' . $scenario['expected_program'] . ' but it is not.');
+
+    // Test if the expected form elements are present.
     $this->assertSame('details', $build['B']['#type'], 'We expect the main container to be a details element but it is not.');
     $this->assertSame('details', $build['B']['query']['#type'], 'We expect the query container to be a details element but it is not.');
     $this->assertSame('textarea', $build['B']['query']['FASTA']['#type'], 'We expect the FASTA input to be a textarea but it is not.');
@@ -543,7 +563,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $this->blast_form->submitForm($form, $form_state);
 
-    $after = (int) \Drupal::database()->select('blastjob')
+    $after = (int) $this->chado_connection->select('blastjob')
       ->condition('blast_program', $values['blast_program'])
       ->countQuery()
       ->execute()
@@ -551,26 +571,58 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $this->assertSame($before + 1, $after, 'Submission did not create a job record for ' . $values['blast_program']);
     $this->assertNotNull($form_state->getRedirect(), 'Expected a redirect after form submission but none was found.');
+    $this->assertNotEmpty($_SESSION['blast_jobs'], "Expected a session variable for blast_jobs to be set after form submission but it was not found.");
   }
 
   /**
-   * Tests buildForm covers warning, recent-job, and resubmit defaults.
+   * Tests the buildForm related warning messages.
    */
-  public function testBuildFormCoversWarningsRecentJobsAndResubmitDefaults(): void {
-    $editable_config = \Drupal::service('config.factory')->getEditable('tripal_blast.settings');
-    $editable_config->set('tripal_blast_config_notification.warning_text', 'Temporary maintenance warning');
-    $editable_config->set('tripal_blast_config_sequence.nucleotide', '>example\nACGT');
-    $editable_config->save();
+  public function testBuildFormDisplaysWarningMessage(): void {
+    $editable_config = $this->config('tripal_blast.settings');
+    $editable_config
+      ->set(
+        'tripal_blast_config_notification.warning_text',
+        'Temporary maintenance warning'
+      )
+      ->save();
 
+    $build = $this->blast_form->buildForm([], new FormState(), 'nucleotide', 'nucleotide');
+
+    $this->assertArrayHasKey('config_warning', $build, 'Expected a warning message in the form build but it was not found.');
+  }
+
+  /**
+   * Tests buildForm recent job display.
+   */
+  public function testBuildFormDisplaysRecentJobs(): void {
+    $job_service = $this->getMockBuilder(\Drupal\tripal_blast\Services\TripalBlastJobService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['jobsCountRecentJobs', 'jobsCreateTable'])
+      ->getMock();
+
+    $job_service->method('jobsCountRecentJobs')->willReturn(1);
+    $job_service->method('jobsCreateTable')->willReturn(['#type' => 'table']);
+
+    $this->container->set('tripal_blast.job_service', $job_service);
+
+    $build = $this->blast_form->buildForm([], new FormState(), 'nucleotide', 'nucleotide');
+
+    $this->assertArrayHasKey('A', $build, 'Expected a recent job container in the form build but it was not found.');
+    $this->assertSame('table', $build['A']['recent_job']['#type'], 'Expected the recent job container to be a table but it is not.');
+  }
+
+  /**
+   * Tests if the buildForm resubmits correct defaults.
+   */
+  public function testBuildFormResubmitPopulatesDefaultValues(): void {
     $query_file = $this->container->get('file_system')->getTempDirectory() . '/resubmit_query.fasta';
     file_put_contents($query_file, ">query\nACGT");
 
     $job_service = $this->getMockBuilder(\Drupal\tripal_blast\Services\TripalBlastJobService::class)
       ->disableOriginalConstructor()
-      ->onlyMethods(['jobsCountRecentJobs', 'jobsCreateTable', 'jobsBlastRevealSecret', 'jobsGetJobByJobId'])
+      ->onlyMethods(['jobsBlastRevealSecret', 'jobsGetJobByJobId'])
       ->getMock();
-    $job_service->method('jobsCountRecentJobs')->willReturn(1);
-    $job_service->method('jobsCreateTable')->willReturn(['#type' => 'table']);
+
     $job_service->method('jobsBlastRevealSecret')->willReturn(42);
     $job_service->method('jobsGetJobByJobId')->willReturn((object) [
       'blastdb' => (object) ['nid' => 99],
@@ -580,13 +632,8 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     \Drupal::request()->query->set('resubmit', 'secret-id');
 
-    $form = [];
-    $form_state = new FormState();
-    $build = $this->blast_form->buildForm($form, $form_state, 'nucleotide', 'nucleotide');
+    $build = $this->blast_form->buildForm([], new FormState(), 'nucleotide', 'nucleotide');
 
-    $this->assertArrayHasKey('config_warning', $build, 'Expected a warning message in the form build but it was not found.');
-    $this->assertArrayHasKey('A', $build, 'Expected a recent job container in the form build but it was not found.');
-    $this->assertSame('table', $build['A']['recent_job']['#type'], 'Expected the recent job container to be a table but it is not.');
     $this->assertSame(99, $build['B']['db']['SELECT_DB']['#default_value'], 'Expected the default database value to be 99 but it is not.');
     $this->assertSame(">query\nACGT", $build['B']['query']['FASTA']['#default_value'], 'Expected the default query value to be the correct sequence but it is not.');
   }
@@ -661,7 +708,13 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'gapCost' => '5,2',
     ]);
     $this->blast_form->submitForm($form, $form_state);
-    $this->assertNotNull($form_state->getRedirect());
+    $this->assertNotNull($form_state->getRedirect(), "Expeccted a redirect object, but it was NULL.");
+    $redirect_path = $form_state->getRedirect()->getInternalPath();
+    $this->assertSame(
+      'blast/report/encoded-job',
+      $redirect_path,
+      "We expected the redirect route to be 'blast/report/encoded-job' but it was $redirect_path."
+    );
   }
 
   /**
@@ -674,7 +727,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       ->getMock();
     $job_service->expects($this->once())
       ->method('createBlastJob')
-      ->willThrowException(new \RuntimeException('boom'));
+      ->willThrowException(new \RuntimeException('Unable to create tripal job'));
     $this->container->set('tripal_blast.job_service', $job_service);
 
     $form = [];
@@ -697,7 +750,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $messages = \Drupal::messenger()->all();
     $this->assertNotEmpty($messages['error'], 'Expected an error message but none were found.');
-    $this->assertStringContainsString("Unable to submit the BLAST job. The error was: boom", reset($messages['error']), 'Expected error message about job creation but it was not found.');
+    $this->assertStringContainsString("Unable to submit the BLAST job. The error was: Unable to create tripal job", reset($messages['error']), 'Expected error message about job creation but it was not found.');
   }
 
   /**
@@ -737,7 +790,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
    *
    * @return array
    */
-  public static function provideDataForTestProgamGetGapCostInAjaxCallback(): array {
+  public static function provideDataForTestProgramGetGapCostInAjaxCallback(): array {
     return [
       'blastn with m&m score 0' => [
         [
@@ -814,10 +867,10 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
    * @param array $data
    *   The form values to test the AJAX callback with.
    *
-   * @dataProvider provideDataForTestProgamGetGapCostInAjaxCallback
+   * @dataProvider provideDataForTestProgramGetGapCostInAjaxCallback
    */
-  #[DataProvider('provideDataForTestProgamGetGapCostInAjaxCallback')]
-  public function testProgamGetGapCostInAjaxCallback(array $data, array $result): void {
+  #[DataProvider('provideDataForTestProgramGetGapCostInAjaxCallback')]
+  public function testProgramGetGapCostInAjaxCallback(array $data, array $result): void {
     $form = [];
     $form_state = new FormState();
     $form_state->setValues($data);
@@ -1050,8 +1103,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->assertArrayHasKey('query', $errors, 'Expected an error for query but it was not found.');
     $this->assertStringContainsString("The file should be a plain-text FASTA
           (.fasta, .fna, .fa, .fas) file. In other words, it cannot have formatting as is the
-          case with MS Word (.doc, .docx) or Rich Text Format (.rtf). It cannot be greater
-          than %max_size in size.", $errors['query'], 'Expected error message about job creation but it was not found.');
+          case with MS Word (.doc, .docx) or Rich Text Format (.rtf).", $errors['query'], 'Expected error message about job creation but it was not found.');
   }
 
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -102,6 +102,12 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->assertSame('tripalblastform', $this->blast_form->getFormId());
   }
 
+  /**
+   * Provides data for testBuildForm.
+   *
+   * @return array
+   *   An array of test scenarios, each containing query type, database type, and expected program.
+   */
   public static function provideDataForTestBuildForm(): array {
     return [
       'nucleotide blastn' => [
@@ -160,6 +166,12 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->assertSame('submit', $build['B']['submit']['#type'], 'We expect the submit button to be a submit element but it is not.');
   }
 
+  /**
+   * Provides data for testValidateForm.
+   *
+   * @return array
+   *   An array of test scenarios, each containing form values and expected results.
+   */
   public static function provideDataForTestValidateForm(): array {
     return [
       'missing query and database' => [
@@ -400,6 +412,12 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     }
   }
 
+  /**
+   * Provides data for testSubmitForm.
+   *
+   * @return array
+   *   An array of test scenarios, each containing form values to submit.
+   */
   public static function provideDataForTestSubmitForm(): array {
     return [
       'valid blastn' => [

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -3,10 +3,11 @@
 namespace Drupal\Tests\tripal_blast\Kernel;
 
 use Drupal\Core\Form\FormState;
-use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_blast\Form\TripalBlastForm;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Tests the Tripal BLAST form.
@@ -17,12 +18,12 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  */
 #[Group('tripal-blast')]
 #[RunTestsInSeparateProcesses]
-class TripalBlastFormTest extends TripalTestKernelBase {
+class TripalBlastFormTest extends ChadoTestKernelBase {
 
   /**
    * {@inheritdoc}
    */
-  protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_blast'];
+  protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_chado','tripal_blast'];
 
   /**
    * Class instance of the Tripal Blast Form.
@@ -32,12 +33,24 @@ class TripalBlastFormTest extends TripalTestKernelBase {
   protected $blast_form;
 
   /**
+   * A Database query interface for querying Chado using Tripal DBX.
+   *
+   * @var \Drupal\tripal_chado\Database\ChadoConnection
+   */
+  protected ChadoConnection $chado_connection;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
     parent::setUp();
     \Drupal::state()->set('is_a_test_environment', TRUE);
+
+    // Create a test chado instance as needed by our service.
+    $this->chado_connection = $this->createTestSchema(ChadoTestKernelBase::PREPARE_TEST_CHADO);
+
     $this->installConfig(['tripal_blast', 'system']);
+    $this->installSchema('tripal_blast', ['blastjob']);
 
     $this->blast_form = TripalBlastForm::create($this->container);
   }
@@ -141,4 +154,51 @@ class TripalBlastFormTest extends TripalTestKernelBase {
     $this->assertSame('seqQuery', $form_state->getValue('qFlag'));
     $this->assertSame('blastdb', $form_state->getValue('dbFlag'));
   }
+
+  /**
+   * Tests validation succeeds for all BLAST programs.
+   */
+  public function testValidateFormAcceptsAllBlastPrograms(): void {
+    $programs = [
+      ['query' => 'nucleotide', 'db' => 'nucleotide', 'program' => 'blastn'],
+      ['query' => 'nucleotide', 'db' => 'protein', 'program' => 'blastx'],
+      ['query' => 'protein', 'db' => 'nucleotide', 'program' => 'tblastn'],
+      ['query' => 'protein', 'db' => 'protein', 'program' => 'blastp'],
+    ];
+
+    foreach ($programs as $program) {
+      $form = [];
+      $form_state = new FormState();
+      if ($program['program'] == 'blastn') {
+        $form_state->setValues([
+          'blast_program' => $program['program'],
+          'query_type' => $program['query'],
+          'db_type' => $program['db'],
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '1',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ]);
+      }
+      else {
+        $form_state->setValues([
+          'blast_program' => $program['program'],
+          'query_type' => $program['query'],
+          'db_type' => $program['db'],
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '1',
+        ]);
+      }
+
+      $this->blast_form->validateForm($form, $form_state);
+
+      $this->assertSame([], $form_state->getErrors(), 'Unexpected validation errors for ' . $program['program']);
+      $this->assertSame('seqQuery', $form_state->getValue('qFlag'), 'Query flag was not set for ' . $program['program']);
+      $this->assertSame('blastdb', $form_state->getValue('dbFlag'), 'Database flag was not set for ' . $program['program']);
+    }
+  }
+
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -776,9 +776,9 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'M&MScores' => 0,
     ]);
 
-    $updated_form = $this->blast_form->ajaxShowExampleSequenceCallback($form, $form_state);
-    $this->assertSame('>example\nACGT', $updated_form['#value'], 'Expected the FASTA field to be updated with the example sequence but it was not.');
-    $this->assertStringContainsString('tripal-blast-tip', $updated_form['#suffix'], 'Expected the FASTA field to have a tip suffix but it does not.');
+    $this->blast_form->ajaxShowExampleSequenceCallback($form, $form_state);
+    $this->assertSame('>example\nACGT', $form['B']['query']['FASTA']['#value'], 'Expected the FASTA field to be updated with the example sequence but it was not.');
+    $this->assertStringContainsString('tripal-blast-tip', $form['B']['query']['FASTA']['#suffix'], 'Expected the FASTA field to have a tip suffix but it does not.');
 
     $response = $this->blast_form->ajaxFieldUpdateCallback($form, $form_state);
     $this->assertInstanceOf(AjaxResponse::class, $response);

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -111,14 +111,14 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $build = $this->blast_form->buildForm($form, $form_state, 'nucleotide', 'nucleotide');
 
-    $this->assertSame('nucleotide', $build['query_type']['#value']);
-    $this->assertSame('nucleotide', $build['db_type']['#value']);
-    $this->assertSame('blastn', $build['blast_program']['#value']);
-    $this->assertSame('details', $build['B']['#type']);
-    $this->assertSame('details', $build['B']['query']['#type']);
-    $this->assertSame('textarea', $build['B']['query']['FASTA']['#type']);
-    $this->assertSame('select', $build['B']['db']['SELECT_DB']['#type']);
-    $this->assertSame('submit', $build['B']['submit']['#type']);
+    $this->assertSame('nucleotide', $build['query_type']['#value'], 'We expect the query type to be nucleotide but it is not.');
+    $this->assertSame('nucleotide', $build['db_type']['#value'], 'We expect the database type to be nucleotide but it is not.');
+    $this->assertSame('blastn', $build['blast_program']['#value'], 'We expect the BLAST program to be blastn but it is not.');
+    $this->assertSame('details', $build['B']['#type'], 'We expect the main container to be a details element but it is not.');
+    $this->assertSame('details', $build['B']['query']['#type'], 'We expect the query container to be a details element but it is not.');
+    $this->assertSame('textarea', $build['B']['query']['FASTA']['#type'], 'We expect the FASTA input to be a textarea but it is not.');
+    $this->assertSame('select', $build['B']['db']['SELECT_DB']['#type'], 'We expect the database selection to be a select element but it is not.');
+    $this->assertSame('submit', $build['B']['submit']['#type'], 'We expect the submit button to be a submit element but it is not.');
   }
 
   /**
@@ -165,8 +165,8 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->blast_form->validateForm($form, $form_state);
 
     $errors = $form_state->getErrors();
-    $this->assertArrayHasKey('query', $errors);
-    $this->assertArrayHasKey('db', $errors);
+    $this->assertArrayHasKey('query', $errors, 'Expected an error for missing query but it was not found.');
+    $this->assertArrayHasKey('db', $errors, 'Expected an error for missing database but it was not found.');
   }
 
   /**
@@ -190,9 +190,9 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $this->blast_form->validateForm($form, $form_state);
 
-    $this->assertSame([], $form_state->getErrors());
-    $this->assertSame('seqQuery', $form_state->getValue('qFlag'));
-    $this->assertSame('blastdb', $form_state->getValue('dbFlag'));
+    $this->assertSame([], $form_state->getErrors(), 'Unexpected validation errors found.');
+    $this->assertSame('seqQuery', $form_state->getValue('qFlag'), 'Query flag was not set correctly.');
+    $this->assertSame('blastdb', $form_state->getValue('dbFlag'), 'Database flag was not set correctly.');
   }
 
   /**
@@ -349,11 +349,11 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $form_state = new FormState();
     $build = $this->blast_form->buildForm($form, $form_state, 'nucleotide', 'nucleotide');
 
-    $this->assertArrayHasKey('config_warning', $build);
-    $this->assertArrayHasKey('A', $build);
-    $this->assertSame('table', $build['A']['recent_job']['#type']);
-    $this->assertSame(99, $build['B']['db']['SELECT_DB']['#default_value']);
-    $this->assertSame(">query\nACGT", $build['B']['query']['FASTA']['#default_value']);
+    $this->assertArrayHasKey('config_warning', $build, 'Expected a warning message in the form build but it was not found.');
+    $this->assertArrayHasKey('A', $build, 'Expected a recent job container in the form build but it was not found.');
+    $this->assertSame('table', $build['A']['recent_job']['#type'], 'Expected the recent job container to be a table but it is not.');
+    $this->assertSame(99, $build['B']['db']['SELECT_DB']['#default_value'], 'Expected the default database value to be 99 but it is not.');
+    $this->assertSame(">query\nACGT", $build['B']['query']['FASTA']['#default_value'], 'Expected the default query value to be the correct sequence but it is not.');
   }
 
   /**
@@ -405,10 +405,10 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $this->blast_form->validateForm($form, $form_state);
 
-    $this->assertSame('upQuery', $form_state->getValue('qFlag'));
-    $this->assertSame('upDB', $form_state->getValue('dbFlag'));
-    $this->assertNotEmpty($form_state->getErrors());
-    $this->assertArrayHasKey('eVal', $form_state->getErrors());
+    $this->assertSame('upQuery', $form_state->getValue('qFlag'), 'Expected the query flag to be set to upQuery but it is not.');
+    $this->assertSame('upDB', $form_state->getValue('dbFlag'), 'Expected the database flag to be set to upDB but it is not.');
+    $this->assertNotEmpty($form_state->getErrors(), 'Expected validation errors but none were found.');
+    $this->assertArrayHasKey('eVal', $form_state->getErrors(), 'Expected an error for invalid eVal but it was not found.');
   }
 
   /**
@@ -433,7 +433,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->blast_form->submitForm($form, $form_state);
 
     $messages = \Drupal::messenger()->all();
-    $this->assertNotEmpty($messages['error']);
+    $this->assertNotEmpty($messages['error'], 'Expected an error message but none were found.');
   }
 
   /**
@@ -517,7 +517,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->blast_form->submitForm($form, $form_state);
 
     $messages = \Drupal::messenger()->all();
-    $this->assertNotEmpty($messages['error']);
+    $this->assertNotEmpty($messages['error'], 'Expected an error message but none were found.');
   }
 
   /**
@@ -544,12 +544,12 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     ]);
 
     $updated_form = $this->blast_form->ajaxShowExampleSequenceCallback($form, $form_state);
-    $this->assertSame('>example\nACGT', $updated_form['#value']);
-    $this->assertStringContainsString('tripal-blast-tip', $updated_form['#suffix']);
+    $this->assertSame('>example\nACGT', $updated_form['#value'], 'Expected the FASTA field to be updated with the example sequence but it was not.');
+    $this->assertStringContainsString('tripal-blast-tip', $updated_form['#suffix'], 'Expected the FASTA field to have a tip suffix but it does not.');
 
     $response = $this->blast_form->ajaxFieldUpdateCallback($form, $form_state);
     $this->assertInstanceOf(AjaxResponse::class, $response);
-    $this->assertNotEmpty($response->getCommands());
+    $this->assertNotEmpty($response->getCommands(), 'Expected the AJAX response to contain commands but it does not.');
   }
 
   /**
@@ -613,7 +613,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $this->blast_form->validateForm($form, $form_state);
 
-    $this->assertArrayHasKey($key, $form_state->getErrors());
+    $this->assertArrayHasKey($key, $form_state->getErrors(), 'Expected an error for invalid ' . $key . ' but it was not found.');
   }
 
   /**
@@ -640,7 +640,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $this->blast_form->validateForm($form, $form_state);
 
-    $this->assertSame('blastdb', $form_state->getValue('dbFlag'));
+    $this->assertSame('blastdb', $form_state->getValue('dbFlag'), 'Expected the database flag to be set to blastdb but it is not.');
   }
 
   /**
@@ -676,7 +676,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     ]);
     $this->blast_form->submitForm($form, $form_state);
 
-    $this->assertNotNull($form_state->getRedirect());
+    $this->assertNotNull($form_state->getRedirect(), 'Expected a redirect after form submission but none was found.');
   }
 
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -102,18 +102,57 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->assertSame('tripalblastform', $this->blast_form->getFormId());
   }
 
+  public static function provideDataForTestBuildForm(): array {
+    return [
+      'nucleotide blastn' => [
+        [
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'expected_program' => 'blastn',
+        ],
+      ],
+      'nucleotide blastx' => [
+        [
+        'query_type' => 'nucleotide',
+        'db_type' => 'protein',
+        'expected_program' => 'blastx',
+        ],
+      ],
+      'protein tblastn' => [
+        [
+          'query_type' => 'protein',
+          'db_type' => 'nucleotide',
+          'expected_program' => 'tblastn',
+        ],
+      ],
+      'protein blastp' => [
+        [
+          'query_type' => 'protein',
+          'db_type' => 'protein',
+          'expected_program' => 'blastp',
+        ],
+      ],
+    ];
+  }
+
   /**
    * Tests that the build form contains the expected BLAST fields.
+   *
+   * @param array $scenario
+   *  The scenario data containing query type, database type, and expected program.
+   *
+   * @dataProvider provideDataForTestBuildForm
    */
-  public function testBuildFormContainsExpectedFields(): void {
+  #[DataProvider('provideDataForTestBuildForm')]
+  public function testBuildForm(array $scenario): void {
     $form = [];
     $form_state = new FormState();
 
-    $build = $this->blast_form->buildForm($form, $form_state, 'nucleotide', 'nucleotide');
+    $build = $this->blast_form->buildForm($form, $form_state, $scenario['query_type'], $scenario['db_type']);
 
-    $this->assertSame('nucleotide', $build['query_type']['#value'], 'We expect the query type to be nucleotide but it is not.');
-    $this->assertSame('nucleotide', $build['db_type']['#value'], 'We expect the database type to be nucleotide but it is not.');
-    $this->assertSame('blastn', $build['blast_program']['#value'], 'We expect the BLAST program to be blastn but it is not.');
+    $this->assertSame($scenario['query_type'], $build['query_type']['#value'], 'We expect the query type to be ' . $scenario['query_type'] . ' but it is not.');
+    $this->assertSame($scenario['db_type'], $build['db_type']['#value'], 'We expect the database type to be ' . $scenario['db_type'] . ' but it is not.');
+    $this->assertSame($scenario['expected_program'], $build['blast_program']['#value'], 'We expect the BLAST program to be ' . $scenario['expected_program'] . ' but it is not.');
     $this->assertSame('details', $build['B']['#type'], 'We expect the main container to be a details element but it is not.');
     $this->assertSame('details', $build['B']['query']['#type'], 'We expect the query container to be a details element but it is not.');
     $this->assertSame('textarea', $build['B']['query']['FASTA']['#type'], 'We expect the FASTA input to be a textarea but it is not.');
@@ -121,99 +160,29 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->assertSame('submit', $build['B']['submit']['#type'], 'We expect the submit button to be a submit element but it is not.');
   }
 
-  /**
-   * Tests that each BLAST program builds the expected hidden values.
-   */
-  public function testBuildFormGeneratesAllBlastPrograms(): void {
-    $programs = [
-      ['query' => 'nucleotide', 'db' => 'nucleotide', 'expected' => 'blastn'],
-      ['query' => 'nucleotide', 'db' => 'protein', 'expected' => 'blastx'],
-      ['query' => 'protein', 'db' => 'nucleotide', 'expected' => 'tblastn'],
-      ['query' => 'protein', 'db' => 'protein', 'expected' => 'blastp'],
-    ];
-
-    foreach ($programs as $program) {
-      $form = [];
-      $form_state = new FormState();
-      $build = $this->blast_form->buildForm($form, $form_state, $program['query'], $program['db']);
-
-      $this->assertSame($program['query'], $build['query_type']['#value'], 'Unexpected query type for ' . $program['expected']);
-      $this->assertSame($program['db'], $build['db_type']['#value'], 'Unexpected database type for ' . $program['expected']);
-      $this->assertSame($program['expected'], $build['blast_program']['#value'], 'Unexpected BLAST program for ' . $program['expected']);
-      $this->assertArrayHasKey('B', $build, 'The main details container is missing for ' . $program['expected']);
-      $this->assertArrayHasKey('submit', $build['B'], 'The submit button is missing for ' . $program['expected']);
-    }
-  }
-
-  /**
-   * Tests validation fails when the query and database are missing.
-   */
-  public function testValidateFormRejectsMissingQueryAndDatabase(): void {
-    $form = [];
-    $form_state = new FormState();
-    $form_state->setValues([
-      'blast_program' => 'blastn',
-      'query_type' => 'nucleotide',
-      'db_type' => 'nucleotide',
-      'maxTarget' => '50',
-      'eVal' => '1e-5',
-      'wordSize' => '11',
-      'M&MScores' => '1,-2',
-      'gapCost' => '5,2',
-    ]);
-
-    $this->blast_form->validateForm($form, $form_state);
-
-    $errors = $form_state->getErrors();
-    $this->assertArrayHasKey('query', $errors, 'Expected an error for missing query but it was not found.');
-    $this->assertArrayHasKey('db', $errors, 'Expected an error for missing database but it was not found.');
-  }
-
-  /**
-   * Tests validation accepts a valid FASTA sequence and database selection.
-   */
-  public function testValidateFormAcceptsValidFastaAndDatabaseSelection(): void {
-    $form = [];
-    $form_state = new FormState();
-    $form_state->setValues([
-      'blast_program' => 'blastn',
-      'query_type' => 'nucleotide',
-      'db_type' => 'nucleotide',
-      'FASTA' => ">seq\nACGT",
-      'SELECT_DB' => '1',
-      'maxTarget' => '500',
-      'eVal' => '1e-5',
-      'wordSize' => '11',
-      'M&MScores' => '1,-2',
-      'gapCost' => '5,2',
-    ]);
-
-    $this->blast_form->validateForm($form, $form_state);
-
-    $this->assertSame([], $form_state->getErrors(), 'Unexpected validation errors found.');
-    $this->assertSame('seqQuery', $form_state->getValue('qFlag'), 'Query flag was not set correctly.');
-    $this->assertSame('blastdb', $form_state->getValue('dbFlag'), 'Database flag was not set correctly.');
-  }
-
-  /**
-   * Tests validation succeeds for all BLAST programs.
-   */
-  public function testValidateFormAcceptsAllBlastPrograms(): void {
-    $programs = [
-      ['query' => 'nucleotide', 'db' => 'nucleotide', 'program' => 'blastn'],
-      ['query' => 'nucleotide', 'db' => 'protein', 'program' => 'blastx'],
-      ['query' => 'protein', 'db' => 'nucleotide', 'program' => 'tblastn'],
-      ['query' => 'protein', 'db' => 'protein', 'program' => 'blastp'],
-    ];
-
-    foreach ($programs as $program) {
-      $form = [];
-      $form_state = new FormState();
-      if ($program['program'] == 'blastn') {
-        $form_state->setValues([
-          'blast_program' => $program['program'],
-          'query_type' => $program['query'],
-          'db_type' => $program['db'],
+  public static function provideDataForTestValidateForm(): array {
+    return [
+      'missing query and database' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'maxTarget' => '50',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+        [
+          'expected_error_keys' => ['query', 'db'],
+          'expected_values' => [],
+        ],
+      ],
+      'valid blastn' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
           'FASTA' => ">seq\nACGT",
           'SELECT_DB' => '1',
           'maxTarget' => '500',
@@ -221,40 +190,313 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
           'wordSize' => '11',
           'M&MScores' => '1,-2',
           'gapCost' => '5,2',
-        ]);
-      }
-      else {
-        $form_state->setValues([
-          'blast_program' => $program['program'],
-          'query_type' => $program['query'],
-          'db_type' => $program['db'],
+        ],
+        [
+          'expected_error_keys' => [],
+          'expected_values' => [
+            'qFlag' => 'seqQuery',
+            'dbFlag' => 'blastdb',
+          ],
+        ],
+      ],
+      'valid blastx' => [
+        [
+          'blast_program' => 'blastx',
+          'query_type' => 'nucleotide',
+          'db_type' => 'protein',
           'FASTA' => ">seq\nACGT",
           'SELECT_DB' => '1',
-        ]);
-      }
+        ],
+        [
+          'expected_error_keys' => [],
+          'expected_values' => [
+            'qFlag' => 'seqQuery',
+            'dbFlag' => 'blastdb',
+          ],
+        ],
+      ],
+      'valid tblastn' => [
+        [
+          'blast_program' => 'tblastn',
+          'query_type' => 'protein',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '1',
+        ],
+        [
+          'expected_error_keys' => [],
+          'expected_values' => [
+            'qFlag' => 'seqQuery',
+            'dbFlag' => 'blastdb',
+          ],
+        ],
+      ],
+      'valid blastp' => [
+        [
+          'blast_program' => 'blastp',
+          'query_type' => 'protein',
+          'db_type' => 'protein',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '1',
+        ],
+        [
+          'expected_error_keys' => [],
+          'expected_values' => [
+            'qFlag' => 'seqQuery',
+            'dbFlag' => 'blastdb',
+          ],
+        ],
+      ],
+      'invalid fasta' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'qFlag' => 'seqQuery',
+          'FASTA' => '1234',
+          'SELECT_DB' => '1',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+        [
+          'expected_error_keys' => ['query'],
+          'expected_values' => [],
+        ],
+      ],
+      'valid uploaded query and database' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'UPLOAD' => '1',
+          'DBUPLOAD' => '2',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+        [
+          'expected_error_keys' => [],
+          'expected_values' => [
+            'qFlag' => 'upQuery',
+            'dbFlag' => 'upDB',
+          ],
+        ],
+      ],
+      'invalid DBUPLOAD and SELECT_DB' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'UPLOAD' => '1',
+          'DBUPLOAD' => '500',
+          'SELECT_DB' => '500',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+        [
+          'expected_error_keys' => ['db'],
+          'expected_values' => [],
+        ],
+      ],
+      'invalid DBUPLOAD and missing SELECT_DB' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'qFlag' => 'seqQuery',
+          'FASTA' => ">seq\nACGT",
+          'UPLOAD' => '1',
+          'DBUPLOAD' => '500',
+          'SELECT_DB' => '',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+        [
+          'expected_error_keys' => [],
+          'expected_values' => [
+            'dbFlag' => 'blastdb',
+          ],
+        ],
+      ],
+      'invalid eVal' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '1',
+          'maxTarget' => '500',
+          'eVal' => 'not-a-number',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+        [
+          'expected_error_keys' => ['eVal'],
+          'expected_values' => [],
+        ],
+      ],
+    ];
+  }
 
-      $this->blast_form->validateForm($form, $form_state);
+  /**
+   * Tests that the form validation correctly identifies missing query and database.
+   *
+   * @param array $values
+   *  The form values to validate.
+   * @param array $expected
+   *  The expected results, including expected error keys.
+   *
+   * @dataProvider provideDataForTestValidateForm
+   */
+  #[DataProvider('provideDataForTestValidateForm')]
+  public function testValidateForm(array $values, array $expected): void {
+    $query = ">seq\nACGT";
+    $query_file_uri = 'temporary://tripal-blast-query.fasta';
 
-      $this->assertSame([], $form_state->getErrors(), 'Unexpected validation errors for ' . $program['program']);
-      $this->assertSame('seqQuery', $form_state->getValue('qFlag'), 'Query flag was not set for ' . $program['program']);
-      $this->assertSame('blastdb', $form_state->getValue('dbFlag'), 'Database flag was not set for ' . $program['program']);
+    file_put_contents(
+      \Drupal::service('file_system')->realpath($query_file_uri),
+      $query
+    );
+    $query_file = File::create([
+      'uri' => $query_file_uri,
+    ]);
+    $query_file->save();
+
+    $db_data = ">db\nACGT";
+    $db_file_uri = 'temporary://tripal-blast-db.fasta';
+
+    file_put_contents(
+      \Drupal::service('file_system')->realpath($db_file_uri),
+      $db_data
+    );
+    $db_file = File::create([
+      'uri' => $db_file_uri,
+    ]);
+    $db_file->save();
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues($values);
+
+    $this->blast_form->validateForm($form, $form_state);
+
+    $errors = $form_state->getErrors();
+    foreach ($expected['expected_error_keys'] as $key) {
+      $this->assertArrayHasKey($key, $errors, 'Expected an error for missing ' . $key . ' but it was not found.');
     }
+    foreach ($expected['expected_values'] as $key => $expected_value) {
+      $this->assertSame($expected_value, $form_state->getValue($key), 'Expected the value for ' . $key . ' to be ' . $expected_value . ' but it is not.');
+    }
+  }
+
+  public static function provideDataForTestSubmitForm(): array {
+    return [
+      'valid blastn' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '123450',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+      ],
+      'valid blastx' => [
+        [
+          'blast_program' => 'blastx',
+          'query_type' => 'nucleotide',
+          'db_type' => 'protein',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '67890',
+        ],
+      ],
+      'valid tblastn' => [
+        [
+          'blast_program' => 'tblastn',
+          'query_type' => 'protein',
+          'db_type' => 'nucleotide',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '123450',
+        ],
+      ],
+      'valid blastp' => [
+        [
+          'blast_program' => 'blastp',
+          'query_type' => 'protein',
+          'db_type' => 'protein',
+          'FASTA' => ">seq\nACGT",
+          'SELECT_DB' => '67890',
+        ],
+      ],
+      'valid blastn with uploaded query' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'UPLOAD' => '1',
+          'SELECT_DB' => '123450',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+      ],
+    ];
   }
 
   /**
    * Tests that form submission creates a BLAST job record for each program.
+   *
+   * @param array $values
+   *  The form values to submit.
+   *
+   * @dataProvider provideDataForTestSubmitForm
    */
-  public function testSubmitFormCreatesJobRecordForAllBlastPrograms(): void {
-    $programs = [
-      ['query' => 'nucleotide', 'db' => 'nucleotide', 'program' => 'blastn'],
-      ['query' => 'nucleotide', 'db' => 'protein', 'program' => 'blastx'],
-      ['query' => 'protein', 'db' => 'nucleotide', 'program' => 'tblastn'],
-      ['query' => 'protein', 'db' => 'protein', 'program' => 'blastp'],
-    ];
-
+  #[DataProvider('provideDataForTestSubmitForm')]
+  public function testSubmitForm(array $values): void {
     $editable_config = \Drupal::service('config.factory')->getEditable('tripal_blast.settings');
     $editable_config->set('tripal_blast_config_general.path', 'tmp/true');
     $editable_config->save();
+
+    $query = ">seq\nACGT";
+    $query_file_uri = 'temporary://tripal-blast-query.fasta';
+
+    file_put_contents(
+      \Drupal::service('file_system')->realpath($query_file_uri),
+      $query
+    );
+    $query_file = File::create([
+      'uri' => $query_file_uri,
+    ]);
+    $query_file->save();
+
+    $db_data = ">db\nACGT";
+    $db_file_uri = 'temporary://tripal-blast-db.fasta';
+
+    file_put_contents(
+      \Drupal::service('file_system')->realpath($db_file_uri),
+      $db_data
+    );
+    $db_file = File::create([
+      'uri' => $db_file_uri,
+    ]);
+    $db_file->save();
 
     $fixture_dir = $this->module_path . '/tests/fixtures/Chlamydomonas_reinhardtii_v5.6';
     $nucleotide_db = $this->createBlastDatabase([
@@ -269,53 +511,28 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'path' => $fixture_dir . '/Chlamydomonas_reinhardtii_v5.6_protein.nin',
       'dbtype' => 'p',
     ]);
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues($values);
 
-    foreach ($programs as $program) {
-      $form = [];
-      $form_state = new FormState();
-      $selected_db_id = ($program['db'] === 'protein') ? $protein_db->getId() : $nucleotide_db->getId();
+    $this->blast_form->validateForm($form, $form_state);
 
-      if ($program['program'] == 'blastn') {
-        $form_state->setValues([
-          'blast_program' => $program['program'],
-          'query_type' => $program['query'],
-          'db_type' => $program['db'],
-          'FASTA' => ">seq\nACGT",
-          'SELECT_DB' => (string) $selected_db_id,
-          'maxTarget' => '500',
-          'eVal' => '1e-5',
-          'wordSize' => '11',
-          'M&MScores' => '1,-2',
-          'gapCost' => '5,2',
-        ]);
-      } else {
-        $form_state->setValues([
-          'blast_program' => $program['program'],
-          'query_type' => $program['query'],
-          'db_type' => $program['db'],
-          'FASTA' => ">seq\nACGT",
-          'SELECT_DB' => (string) $selected_db_id,
-        ]);
-      }
+    $before = (int) $this->chado_connection->select('blastjob')
+      ->condition('blast_program', $values['blast_program'])
+      ->countQuery()
+      ->execute()
+      ->fetchField();
 
-      $this->blast_form->validateForm($form, $form_state);
+    $this->blast_form->submitForm($form, $form_state);
 
-      $before = (int) $this->chado_connection->select('blastjob')
-        ->condition('blast_program', $program['program'])
-        ->countQuery()
-        ->execute()
-        ->fetchField();
+    $after = (int) \Drupal::database()->select('blastjob')
+      ->condition('blast_program', $values['blast_program'])
+      ->countQuery()
+      ->execute()
+      ->fetchField();
 
-      $this->blast_form->submitForm($form, $form_state);
-
-      $after = (int) \Drupal::database()->select('blastjob')
-        ->condition('blast_program', $program['program'])
-        ->countQuery()
-        ->execute()
-        ->fetchField();
-
-      $this->assertSame($before + 1, $after, 'Submission did not create a job record for ' . $program['program']);
-    }
+    $this->assertSame($before + 1, $after, 'Submission did not create a job record for ' . $values['blast_program']);
+    $this->assertNotNull($form_state->getRedirect(), 'Expected a redirect after form submission but none was found.');
   }
 
   /**
@@ -357,61 +574,6 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
   }
 
   /**
-   * Tests validation handles uploaded files and invalid advanced values.
-   */
-  public function testValidateFormHandlesUploadedFilesAndInvalidAdvancedValues(): void {
-
-    $query = ">seq\nACGT";
-    $query_file_uri = 'temporary://tripal-blast-query.fasta';
-
-    file_put_contents(
-      \Drupal::service('file_system')->realpath($query_file_uri),
-      $query
-    );
-    $query_file = File::create([
-      'uri' => $query_file_uri,
-    ]);
-    $query_file->save();
-
-    $db_data = ">db\nACGT";
-    $db_file_uri = 'temporary://tripal-blast-db.fasta';
-
-    file_put_contents(
-      \Drupal::service('file_system')->realpath($db_file_uri),
-      $db_data
-    );
-    $db_file = File::create([
-      'uri' => $db_file_uri,
-    ]);
-    $db_file->save();
-
-    $query_file_id = $query_file->id();
-    $db_file_id = $db_file->id();
-
-    $form = [];
-    $form_state = new FormState();
-    $form_state->setValues([
-      'blast_program' => 'blastn',
-      'query_type' => 'nucleotide',
-      'db_type' => 'nucleotide',
-      'UPLOAD' => $query_file_id,
-      'DBUPLOAD' => $db_file_id,
-      'maxTarget' => '500',
-      'eVal' => 'not-a-number',
-      'wordSize' => '11',
-      'M&MScores' => '1,-2',
-      'gapCost' => '5,2',
-    ]);
-
-    $this->blast_form->validateForm($form, $form_state);
-
-    $this->assertSame('upQuery', $form_state->getValue('qFlag'), 'Expected the query flag to be set to upQuery but it is not.');
-    $this->assertSame('upDB', $form_state->getValue('dbFlag'), 'Expected the database flag to be set to upDB but it is not.');
-    $this->assertNotEmpty($form_state->getErrors(), 'Expected validation errors but none were found.');
-    $this->assertArrayHasKey('eVal', $form_state->getErrors(), 'Expected an error for invalid eVal but it was not found.');
-  }
-
-  /**
    * Tests submitForm reports a missing database selection.
    */
   public function testSubmitFormReportsMissingDatabaseSelection(): void {
@@ -434,6 +596,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $messages = \Drupal::messenger()->all();
     $this->assertNotEmpty($messages['error'], 'Expected an error message but none were found.');
+    $this->assertStringContainsString("No BLAST database selected.", reset($messages['error']), 'Expected error message about missing database selection but it was not found.');
   }
 
   /**
@@ -479,9 +642,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
       'M&MScores' => '1,-2',
       'gapCost' => '5,2',
     ]);
-
     $this->blast_form->submitForm($form, $form_state);
-
     $this->assertNotNull($form_state->getRedirect());
   }
 
@@ -518,6 +679,7 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
 
     $messages = \Drupal::messenger()->all();
     $this->assertNotEmpty($messages['error'], 'Expected an error message but none were found.');
+    $this->assertStringContainsString("Unable to submit the BLAST job. The error was: boom", reset($messages['error']), 'Expected error message about job creation but it was not found.');
   }
 
   /**
@@ -550,133 +712,6 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $response = $this->blast_form->ajaxFieldUpdateCallback($form, $form_state);
     $this->assertInstanceOf(AjaxResponse::class, $response);
     $this->assertNotEmpty($response->getCommands(), 'Expected the AJAX response to contain commands but it does not.');
-  }
-
-  /**
-   * Provides data for testing validation errors for missing database and query.
-   *
-   * @return array
-   *   An array of test cases, each containing form values and the expected error key.
-   */
-  public static function provideDataForValidateDatabaseAndQueryErrors(): array {
-    return [
-      'invalid fasta' => [
-        [
-          'blast_program' => 'blastn',
-          'query_type' => 'nucleotide',
-          'db_type' => 'nucleotide',
-          'qFlag' => 'seqQuery',
-          'FASTA' => '1234',
-          'SELECT_DB' => '1',
-          'maxTarget' => '500',
-          'eVal' => '1e-5',
-          'wordSize' => '11',
-          'M&MScores' => '1,-2',
-          'gapCost' => '5,2',
-        ],
-        'query',
-      ],
-      'invalid DBUPLOAD and SELECT_DB' => [
-        [
-          'blast_program' => 'blastn',
-          'query_type' => 'nucleotide',
-          'db_type' => 'nucleotide',
-          'UPLOAD' => '1',
-          'DBUPLOAD' => '500',
-          'SELECT_DB' => '500',
-          'maxTarget' => '500',
-          'eVal' => '1e-5',
-          'wordSize' => '11',
-          'M&MScores' => '1,-2',
-          'gapCost' => '5,2',
-        ],
-        'db',
-      ],
-    ];
-  }
-
-  /**
-   * Tests validation fails for missing database and query.
-   *
-   * @param array $values
-   *  The form values to validate.
-   * @param string $key
-   *  The key of the expected error.
-   *
-   * @dataProvider provideDataForValidateDatabaseAndQueryErrors
-   */
-  #[DataProvider('provideDataForValidateDatabaseAndQueryErrors')]
-  public function testValidateDatabaseAndQueryErrors(array $values, string $key): void {
-    $form = [];
-    $form_state = new FormState();
-    $form_state->setValues($values);
-
-    $this->blast_form->validateForm($form, $form_state);
-
-    $this->assertArrayHasKey($key, $form_state->getErrors(), 'Expected an error for invalid ' . $key . ' but it was not found.');
-  }
-
-  /**
-   * Tests validation fails for an invalid database upload selection.
-   */
-  public function testValidateFormInvalidDBUploadSelection(): void {
-    $form = [];
-    $form_state = new FormState();
-    $form_state->setValues([
-      'blast_program' => 'blastn',
-      'query_type' => 'nucleotide',
-      'db_type' => 'nucleotide',
-      'qFlag' => 'seqQuery',
-      'FASTA' => ">seq\nACGT",
-      'UPLOAD' => '1',
-      'DBUPLOAD' => '500',
-      'SELECT_DB' => '',
-      'maxTarget' => '500',
-      'eVal' => '1e-5',
-      'wordSize' => '11',
-      'M&MScores' => '1,-2',
-      'gapCost' => '5,2',
-    ]);
-
-    $this->blast_form->validateForm($form, $form_state);
-
-    $this->assertSame('blastdb', $form_state->getValue('dbFlag'), 'Expected the database flag to be set to blastdb but it is not.');
-  }
-
-  /**
-   * Tests that submitForm correctly handles the query flag.
-   */
-  public function testSubmitFormQueryFlag(): void {
-    $editable_config = \Drupal::service('config.factory')->getEditable('tripal_blast.settings');
-    $editable_config->set('tripal_blast_config_general.path', 'tmp/true');
-    $editable_config->save();
-
-    $fixture_dir = $this->module_path . '/tests/fixtures/Chlamydomonas_reinhardtii_v5.6';
-    $nucleotide_db = $this->createBlastDatabase([
-      'id' => 123450,
-      'name' => 'Fixture nucleotide BLAST DB',
-      'path' => $fixture_dir . '/Chlamydomonas_reinhardtii_v5.6.nin',
-      'dbtype' => 'n',
-    ]);
-    $form = [];
-    $form_state = new FormState();
-    $form_state->setValues([
-      'blast_program' => 'blastn',
-      'query_type' => 'nucleotide',
-      'db_type' => 'nucleotide',
-      'qFlag' => 'upQuery',
-      'upQuery_path' => $nucleotide_db->getPath(),
-      'FASTA' => ">seq\nACGT",
-      'SELECT_DB' => (string) $nucleotide_db->getId(),
-      'maxTarget' => '500',
-      'eVal' => '1e-5',
-      'wordSize' => '11',
-      'M&MScores' => '1,-2',
-      'gapCost' => '5,2',
-    ]);
-    $this->blast_form->submitForm($form, $form_state);
-
-    $this->assertNotNull($form_state->getRedirect(), 'Expected a redirect after form submission but none was found.');
   }
 
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -834,6 +834,11 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     }
   }
 
+  /**
+   * Provides data for testBlastProgramHelperProgramSetMatchMiss.
+   *
+   * @return array
+   */
   public static function provideDataForTestBlastProgramHelperProgramSetMatchMiss(): array {
     return [
       'blastn with m&m score 0' => [
@@ -973,6 +978,80 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->assertIsArray($captured_submission['options']);
     $this->assertSame($result['match_miss'][1], $captured_submission['options']['penalty'], "The penalty should be {$result['match_miss'][1]} but it was {$captured_submission['options']['penalty']}");
     $this->assertSame($result['match_miss'][0], $captured_submission['options']['reward'], "The penalty should be {$result['match_miss'][0]} but it was {$captured_submission['options']['reward']}");
+  }
+
+  /**
+   * Provide data for testProgramValidateFastaSequence method.
+   *
+   * @return array
+   */
+  public static function provideDataForTestProgramValidateFastaSequence() {
+    return [
+      'not a definition line' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => "> seq\nACGT",
+          'SELECT_DB' => '1',
+          'maxTarget' => '500',
+          'eVal' => 'not-a-number',
+          'wordSize' => '11',
+          'M&MScores' => 0,
+          'gapCost' => '5,2',
+        ],
+      ],
+      'not a sequence line' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'FASTA' => "seq",
+          'SELECT_DB' => '1',
+          'maxTarget' => '500',
+          'eVal' => 'not-a-number',
+          'wordSize' => '11',
+          'M&MScores' => 0,
+          'gapCost' => '5,2',
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Tests the programValidateFastaSequence method in the Helper.
+   *
+   * @param array $values
+   *   Values to be set in the form state.
+   *
+   * @dataProvider provideDataForTestProgramValidateFastaSequence
+   */
+  #[DataProvider('provideDataForTestProgramValidateFastaSequence')]
+  public function testProgramValidateFastaSequence(array $values): void {
+    $db_data = ">db\nACGT";
+    $db_file_uri = 'temporary://tripal-blast-db.fasta';
+
+    file_put_contents(
+      \Drupal::service('file_system')->realpath($db_file_uri),
+      $db_data
+    );
+    $db_file = File::create([
+      'uri' => $db_file_uri,
+    ]);
+    $db_file->save();
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues($values);
+
+    $this->blast_form->validateForm($form, $form_state);
+
+    $errors = $form_state->getErrors();
+    $this->assertNotEmpty($errors, 'Expected an error message but none were found.');
+    $this->assertArrayHasKey('query', $errors, 'Expected an error for query but it was not found.');
+    $this->assertStringContainsString("The file should be a plain-text FASTA
+          (.fasta, .fna, .fa, .fas) file. In other words, it cannot have formatting as is the
+          case with MS Word (.doc, .docx) or Rich Text Format (.rtf). It cannot be greater
+          than %max_size in size.", $errors['query'], 'Expected error message about job creation but it was not found.');
   }
 
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\tripal_blast\Kernel;
 
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Form\FormState;
+use Drupal\file\Entity\File;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\tripal_blast\Traits\TripalBlastTestTrait;
 use Drupal\tripal_blast\Form\TripalBlastForm;
@@ -352,6 +353,202 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $this->assertSame('table', $build['A']['recent_job']['#type']);
     $this->assertSame(99, $build['B']['db']['SELECT_DB']['#default_value']);
     $this->assertSame(">query\nACGT", $build['B']['query']['FASTA']['#default_value']);
+  }
+
+  /**
+   * Tests validation handles uploaded files and invalid advanced values.
+   */
+  public function testValidateFormHandlesUploadedFilesAndInvalidAdvancedValues(): void {
+
+    $query = ">seq\nACGT";
+    $query_file_uri = 'temporary://tripal-blast-query.fasta';
+
+    file_put_contents(
+      \Drupal::service('file_system')->realpath($query_file_uri),
+      $query
+    );
+    $query_file = File::create([
+      'uri' => $query_file_uri,
+    ]);
+    $query_file->save();
+
+    $db_data = ">db\nACGT";
+    $db_file_uri = 'temporary://tripal-blast-db.fasta';
+
+    file_put_contents(
+      \Drupal::service('file_system')->realpath($db_file_uri),
+      $db_data
+    );
+    $db_file = File::create([
+      'uri' => $db_file_uri,
+    ]);
+    $db_file->save();
+
+    $query_file_id = $query_file->id();
+    $db_file_id = $db_file->id();
+
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues([
+      'blast_program' => 'blastn',
+      'query_type' => 'nucleotide',
+      'db_type' => 'nucleotide',
+      'UPLOAD' => $query_file_id,
+      'DBUPLOAD' => $db_file_id,
+      'maxTarget' => '500',
+      'eVal' => 'not-a-number',
+      'wordSize' => '11',
+      'M&MScores' => '1,-2',
+      'gapCost' => '5,2',
+    ]);
+
+    $this->blast_form->validateForm($form, $form_state);
+
+    $this->assertSame('upQuery', $form_state->getValue('qFlag'));
+    $this->assertSame('upDB', $form_state->getValue('dbFlag'));
+    $this->assertNotEmpty($form_state->getErrors());
+    $this->assertArrayHasKey('eVal', $form_state->getErrors());
+  }
+
+  /**
+   * Tests submitForm reports a missing database selection.
+   */
+  public function testSubmitFormReportsMissingDatabaseSelection(): void {
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues([
+      'blast_program' => 'blastn',
+      'query_type' => 'nucleotide',
+      'db_type' => 'nucleotide',
+      'qFlag' => 'seqQuery',
+      'FASTA' => ">seq\nACGT",
+      'maxTarget' => '500',
+      'eVal' => '1e-5',
+      'wordSize' => '11',
+      'M&MScores' => '1,-2',
+      'gapCost' => '5,2',
+    ]);
+
+    $this->blast_form->submitForm($form, $form_state);
+
+    $messages = \Drupal::messenger()->all();
+    $this->assertNotEmpty($messages['error']);
+  }
+
+  /**
+   * Tests submitForm uses an uploaded database and creates a job submission.
+   */
+  public function testSubmitFormUsesUploadedDatabaseAndCreatesJob(): void {
+    $temp_dir = $this->container->get('file_system')->getTempDirectory() . '/tripal-blast-makeblastdb';
+    if (!is_dir($temp_dir)) {
+      mkdir($temp_dir, 0777, TRUE);
+    }
+
+    $makeblastdb_path = $temp_dir . '/makeblastdb';
+    file_put_contents($makeblastdb_path, "#!/bin/sh\nexit 0\n");
+    chmod($makeblastdb_path, 0755);
+
+    $editable_config = \Drupal::service('config.factory')->getEditable('tripal_blast.settings');
+    $editable_config->set('tripal_blast_config_general.path', $temp_dir . '/');
+    $editable_config->save();
+
+    $job_service = $this->getMockBuilder(\Drupal\tripal_blast\Services\TripalBlastJobService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['createBlastJob', 'jobsBlastMakeSecret'])
+      ->getMock();
+    $job_service->expects($this->once())
+      ->method('createBlastJob')
+      ->willReturn(2024);
+    $job_service->method('jobsBlastMakeSecret')->willReturn('encoded-job');
+    $this->container->set('tripal_blast.job_service', $job_service);
+
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues([
+      'blast_program' => 'blastn',
+      'query_type' => 'nucleotide',
+      'db_type' => 'nucleotide',
+      'qFlag' => 'seqQuery',
+      'FASTA' => ">seq\nACGT",
+      'dbFlag' => 'upDB',
+      'upDB_path' => $temp_dir . '/uploaded.fasta',
+      'maxTarget' => '500',
+      'eVal' => '1e-5',
+      'wordSize' => '11',
+      'M&MScores' => '1,-2',
+      'gapCost' => '5,2',
+    ]);
+
+    $this->blast_form->submitForm($form, $form_state);
+
+    $this->assertNotNull($form_state->getRedirect());
+  }
+
+  /**
+   * Tests submitForm catches job creation errors.
+   */
+  public function testSubmitFormCatchesJobCreationErrors(): void {
+    $job_service = $this->getMockBuilder(\Drupal\tripal_blast\Services\TripalBlastJobService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['createBlastJob'])
+      ->getMock();
+    $job_service->expects($this->once())
+      ->method('createBlastJob')
+      ->willThrowException(new \RuntimeException('boom'));
+    $this->container->set('tripal_blast.job_service', $job_service);
+
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues([
+      'blast_program' => 'blastn',
+      'query_type' => 'nucleotide',
+      'db_type' => 'nucleotide',
+      'qFlag' => 'seqQuery',
+      'FASTA' => ">seq\nACGT",
+      'SELECT_DB' => '1',
+      'maxTarget' => '500',
+      'eVal' => '1e-5',
+      'wordSize' => '11',
+      'M&MScores' => '1,-2',
+      'gapCost' => '5,2',
+    ]);
+
+    $this->blast_form->submitForm($form, $form_state);
+
+    $messages = \Drupal::messenger()->all();
+    $this->assertNotEmpty($messages['error']);
+  }
+
+  /**
+   * Tests AJAX callbacks update the form state.
+   */
+  public function testAjaxCallbacksUpdateTheForm(): void {
+    $editable_config = \Drupal::service('config.factory')->getEditable('tripal_blast.settings');
+    $editable_config->set('tripal_blast_config_sequence.nucleotide', '>example\nACGT');
+    $editable_config->save();
+
+    $form = [
+      'B' => [
+        'query' => [
+          'FASTA' => ['#value' => ''],
+        ],
+      ],
+    ];
+    $form_state = new FormState();
+    $form_state->setValues([
+      'query_type' => 'nucleotide',
+      'example_sequence' => TRUE,
+      'blast_program' => 'blastn',
+      'M&MScores' => '1,-2',
+    ]);
+
+    $updated_form = $this->blast_form->ajaxShowExampleSequenceCallback($form, $form_state);
+    $this->assertSame('>example\nACGT', $updated_form['#value']);
+    $this->assertStringContainsString('tripal-blast-tip', $updated_form['#suffix']);
+
+    $response = $this->blast_form->ajaxFieldUpdateCallback($form, $form_state);
+    $this->assertInstanceOf(AjaxResponse::class, $response);
+    $this->assertNotEmpty($response->getCommands());
   }
 
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal\Traits\TripalTestTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the Tripal BLAST form.
@@ -549,6 +550,130 @@ class TripalBlastFormTest extends ChadoTestKernelBase {
     $response = $this->blast_form->ajaxFieldUpdateCallback($form, $form_state);
     $this->assertInstanceOf(AjaxResponse::class, $response);
     $this->assertNotEmpty($response->getCommands());
+  }
+
+  /**
+   * Provides data for testing validation errors for missing database and query.
+   *
+   * @return array
+   *   An array of test cases, each containing form values and the expected error key.
+   */
+  public static function provideDataForValidateDatabaseAndQueryErrors(): array {
+    return [
+      'invalid fasta' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'qFlag' => 'seqQuery',
+          'FASTA' => '1234',
+          'SELECT_DB' => '1',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+        'query',
+      ],
+      'invalid DBUPLOAD and SELECT_DB' => [
+        [
+          'blast_program' => 'blastn',
+          'query_type' => 'nucleotide',
+          'db_type' => 'nucleotide',
+          'UPLOAD' => '1',
+          'DBUPLOAD' => '500',
+          'SELECT_DB' => '500',
+          'maxTarget' => '500',
+          'eVal' => '1e-5',
+          'wordSize' => '11',
+          'M&MScores' => '1,-2',
+          'gapCost' => '5,2',
+        ],
+        'db',
+      ],
+    ];
+  }
+
+  /**
+   * Tests validation fails for missing database and query.
+   *
+   * @param array $values
+   *  The form values to validate.
+   * @param string $key
+   *  The key of the expected error.
+   *
+   * @dataProvider provideDataForValidateDatabaseAndQueryErrors
+   */
+  #[DataProvider('provideDataForValidateDatabaseAndQueryErrors')]
+  public function testValidateDatabaseAndQueryErrors(array $values, string $key): void {
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues($values);
+
+    $this->blast_form->validateForm($form, $form_state);
+
+    $this->assertArrayHasKey($key, $form_state->getErrors());
+  }
+
+  /**
+   * Tests validation fails for an invalid database upload selection.
+   */
+  public function testValidateFormInvalidDBUploadSelection(): void {
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues([
+      'blast_program' => 'blastn',
+      'query_type' => 'nucleotide',
+      'db_type' => 'nucleotide',
+      'qFlag' => 'seqQuery',
+      'FASTA' => ">seq\nACGT",
+      'UPLOAD' => '1',
+      'DBUPLOAD' => '500',
+      'SELECT_DB' => '',
+      'maxTarget' => '500',
+      'eVal' => '1e-5',
+      'wordSize' => '11',
+      'M&MScores' => '1,-2',
+      'gapCost' => '5,2',
+    ]);
+
+    $this->blast_form->validateForm($form, $form_state);
+
+    $this->assertSame('blastdb', $form_state->getValue('dbFlag'));
+  }
+
+  /**
+   * Tests that submitForm correctly handles the query flag.
+   */
+  public function testSubmitFormQueryFlag() :void {
+    $editable_config = \Drupal::service('config.factory')->getEditable('tripal_blast.settings');
+    $editable_config->set('tripal_blast_config_general.path', 'tmp/true');
+    $editable_config->save();
+
+    $fixture_dir = $this->module_path . '/tests/fixtures/Chlamydomonas_reinhardtii_v5.6';
+    $nucleotide_db = $this->createBlastDatabase([
+      'id' => 123450,
+      'name' => 'Fixture nucleotide BLAST DB',
+      'path' => $fixture_dir . '/Chlamydomonas_reinhardtii_v5.6.nin',
+      'dbtype' => 'n',
+    ]);
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues([
+      'blast_program' => 'blastn',
+      'query_type' => 'nucleotide',
+      'db_type' => 'nucleotide',
+      'qFlag' => 'upQuery',
+      'FASTA' => ">seq\nACGT",
+      'SELECT_DB' => (string) $nucleotide_db->getId(),
+      'maxTarget' => '500',
+      'eVal' => '1e-5',
+      'wordSize' => '11',
+      'M&MScores' => '1,-2',
+      'gapCost' => '5,2',
+    ]);
+    $this->blast_form->submitForm($form, $form_state);
   }
 
 }

--- a/tests/src/Kernel/TripalBlastFormTest.php
+++ b/tests/src/Kernel/TripalBlastFormTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Drupal\Tests\tripal_blast\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\Tests\tripal\Kernel\TripalTestKernelBase;
+use Drupal\tripal_blast\Form\TripalBlastForm;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests the Tripal BLAST form.
+ *
+ * @group Tripal
+ * @group TripalBlast
+ * @group TripalBlastForm
+ */
+#[Group('tripal-blast')]
+#[RunTestsInSeparateProcesses]
+class TripalBlastFormTest extends TripalTestKernelBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'user', 'file', 'tripal', 'tripal_blast'];
+
+  /**
+   * Class instance of the Tripal Blast Form.
+   *
+   * @var \Drupal\tripal_blast\Form\TripalBlastForm
+   */
+  protected $blast_form;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+    $this->installConfig(['tripal_blast', 'system']);
+
+    $this->blast_form = TripalBlastForm::create($this->container);
+  }
+
+  /**
+   * Tests that the form id is the expected value.
+   */
+  public function testGetFormId(): void {
+    $this->assertSame('tripalblastform', $this->blast_form->getFormId());
+  }
+
+  /**
+   * Tests that the build form contains the expected BLAST fields.
+   */
+  public function testBuildFormContainsExpectedFields(): void {
+    $form = [];
+    $form_state = new FormState();
+
+    $build = $this->blast_form->buildForm($form, $form_state, 'nucleotide', 'nucleotide');
+
+    $this->assertSame('nucleotide', $build['query_type']['#value']);
+    $this->assertSame('nucleotide', $build['db_type']['#value']);
+    $this->assertSame('blastn', $build['blast_program']['#value']);
+    $this->assertSame('details', $build['B']['#type']);
+    $this->assertSame('details', $build['B']['query']['#type']);
+    $this->assertSame('textarea', $build['B']['query']['FASTA']['#type']);
+    $this->assertSame('select', $build['B']['db']['SELECT_DB']['#type']);
+    $this->assertSame('submit', $build['B']['submit']['#type']);
+  }
+
+  /**
+   * Tests that each BLAST program builds the expected hidden values.
+   */
+  public function testBuildFormGeneratesAllBlastPrograms(): void {
+    $programs = [
+      ['query' => 'nucleotide', 'db' => 'nucleotide', 'expected' => 'blastn'],
+      ['query' => 'nucleotide', 'db' => 'protein', 'expected' => 'blastx'],
+      ['query' => 'protein', 'db' => 'nucleotide', 'expected' => 'tblastn'],
+      ['query' => 'protein', 'db' => 'protein', 'expected' => 'blastp'],
+    ];
+
+    foreach ($programs as $program) {
+      $form = [];
+      $form_state = new FormState();
+      $build = $this->blast_form->buildForm($form, $form_state, $program['query'], $program['db']);
+
+      $this->assertSame($program['query'], $build['query_type']['#value'], 'Unexpected query type for ' . $program['expected']);
+      $this->assertSame($program['db'], $build['db_type']['#value'], 'Unexpected database type for ' . $program['expected']);
+      $this->assertSame($program['expected'], $build['blast_program']['#value'], 'Unexpected BLAST program for ' . $program['expected']);
+      $this->assertArrayHasKey('B', $build, 'The main details container is missing for ' . $program['expected']);
+      $this->assertArrayHasKey('submit', $build['B'], 'The submit button is missing for ' . $program['expected']);
+    }
+  }
+
+  /**
+   * Tests validation fails when the query and database are missing.
+   */
+  public function testValidateFormRejectsMissingQueryAndDatabase(): void {
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues([
+      'blast_program' => 'blastn',
+      'query_type' => 'nucleotide',
+      'db_type' => 'nucleotide',
+      'maxTarget' => '50',
+      'eVal' => '1e-5',
+      'wordSize' => '11',
+      'M&MScores' => '1,-2',
+      'gapCost' => '5,2',
+    ]);
+
+    $this->blast_form->validateForm($form, $form_state);
+
+    $errors = $form_state->getErrors();
+    $this->assertArrayHasKey('query', $errors);
+    $this->assertArrayHasKey('db', $errors);
+  }
+
+  /**
+   * Tests validation accepts a valid FASTA sequence and database selection.
+   */
+  public function testValidateFormAcceptsValidFastaAndDatabaseSelection(): void {
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValues([
+      'blast_program' => 'blastn',
+      'query_type' => 'nucleotide',
+      'db_type' => 'nucleotide',
+      'FASTA' => ">seq\nACGT",
+      'SELECT_DB' => '1',
+      'maxTarget' => '500',
+      'eVal' => '1e-5',
+      'wordSize' => '11',
+      'M&MScores' => '1,-2',
+      'gapCost' => '5,2',
+    ]);
+
+    $this->blast_form->validateForm($form, $form_state);
+
+    $this->assertSame([], $form_state->getErrors());
+    $this->assertSame('seqQuery', $form_state->getValue('qFlag'));
+    $this->assertSame('blastdb', $form_state->getValue('dbFlag'));
+  }
+}


### PR DESCRIPTION
## Description

There's been some bugs associated with the Blast Submission Form, and currently lacks sufficient automated test coverage. To help prevent  those, we need to add tests covering both form generation and form submission behavior for all four supported BLAST programs.

## Task

- [x] Add form generation tests for all 4 BLAST programs
- [x] Verify program-specific fields and configuration are generated correctly
- [x] Test form submission for all four BLAST programs
- [x] Add full code coverage for `TripalBlastProgramHelper` class (missing coverage for the methods that are not being used in the current code)
- [ ] Add full test coverage for `src/Form/TripalBlastForm.php` (if not covered by above)

## Automated Testing

- This PR adds the test class `TripalBlastFormTest` which tests the functionality of TripalBlastForm across all 4 BLAST programs.

## **Note**

Since we don't have the query file upload functionality implemented, we're missing some coverage for query file upload related methods.